### PR TITLE
trim source code of file before checking for sourcemap

### DIFF
--- a/src/file-change-cache.js
+++ b/src/file-change-cache.js
@@ -311,7 +311,8 @@ export default class FileChangedCache {
    * @private
    */
   static hasSourceMap(sourceCode) {
-    return sourceCode.lastIndexOf('//# sourceMap') > sourceCode.lastIndexOf('\n');
+    const trimmed = sourceCode.trim();
+    return trimmed.lastIndexOf('//# sourceMap') > trimmed.lastIndexOf('\n');
   }
 
   /**


### PR DESCRIPTION
the file-change-cache does a sourcemap check, which works by checking if the last line of the file is a sourcemap comment. Sourcemaps sitll work with a trailing newline, and this check was not accounting for that. Just trimming the source to nip any trailing newlines when doing the check fixes it though. Just as en example use case, psc (pursecript compiler) puts a trailing newline on a file. also, Atom by default if you edit a compiled file for debugging will add a trailing newline. 

Fixes: #84 