### PR TITLE
add -c/--cachedir for configurable cachedir, and add to init

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -18,9 +18,9 @@ process.on('uncaughtException', (e) => {
   d(e.stack || '');
 });
 
-async function main(appDir, sourceDirs) {
+async function main(appDir, sourceDirs, cacheDir) {
   let compilerHost = null;
-  let rootCacheDir = path.join(appDir, '.cache');
+  let rootCacheDir = path.join(appDir, cacheDir);
   mkdirp.sync(rootCacheDir);
 
   if (process.env.NODE_ENV !== 'production') {
@@ -60,6 +60,9 @@ const yargs = require('yargs')
   .alias('a', 'appdir')
   .describe('a', 'The top-level application directory (i.e. where your package.json is)')
   .default('a', process.cwd())
+  .alias('c', 'cachedir')
+  .describe('c', 'The directory to put the cache')
+  .default('c', '.cache')
   .help('h')
   .alias('h', 'help')
   .epilog('Copyright 2015');
@@ -73,8 +76,9 @@ if (!argv._ || argv._.length < 1) {
 
 const sourceDirs = argv._;
 const appDir = argv.a;
+const cacheDir = argv.c;
 
-main(appDir, sourceDirs)
+main(appDir, sourceDirs, cacheDir)
   .then(() => process.exit(0))
   .catch((e) => {
     console.error(e.message || e);

--- a/src/compile-cache.js
+++ b/src/compile-cache.js
@@ -10,30 +10,30 @@ const d = require('debug')('electron-compile:compile-cache');
 /**
  * CompileCache manages getting and setting entries for a single compiler; each
  * in-use compiler will have an instance of this class, usually created via
- * {@link createFromCompiler}. 
- * 
- * You usually will not use this class directly, it is an implementation class 
+ * {@link createFromCompiler}.
+ *
+ * You usually will not use this class directly, it is an implementation class
  * for {@link CompileHost}.
- */ 
+ */
 export default class CompileCache {
-  /**  
+  /**
    * Creates an instance, usually used for testing only.
-   *    
+   *
    * @param  {string} cachePath  The root directory to use as a cache path
    *
-   * @param  {FileChangedCache} fileChangeCache  A file-change cache that is 
+   * @param  {FileChangedCache} fileChangeCache  A file-change cache that is
    *                                             optionally pre-loaded.
-   */   
+   */
   constructor(cachePath, fileChangeCache) {
     this.cachePath = cachePath;
     this.fileChangeCache = fileChangeCache;
   }
-  
-  /**  
-   * Creates a CompileCache from a class compatible with the CompilerBase 
-   * interface. This method uses the compiler name / version / options to 
+
+  /**
+   * Creates a CompileCache from a class compatible with the CompilerBase
+   * interface. This method uses the compiler name / version / options to
    * generate a unique directory name for cached results
-   *    
+   *
    * @param  {string} cachePath  The root path to use for the cache, a directory
    *                             representing the hash of the compiler parameters
    *                             will be created here.
@@ -41,13 +41,13 @@ export default class CompileCache {
    * @param  {CompilerBase} compiler  The compiler to use for version / option
    *                                  information.
    *
-   * @param  {FileChangedCache} fileChangeCache  A file-change cache that is 
+   * @param  {FileChangedCache} fileChangeCache  A file-change cache that is
    *                                             optionally pre-loaded.
    *
    * @param  {boolean} readOnlyMode  Don't attempt to create the cache directory.
    *
    * @return {CompileCache}  A configured CompileCache instance.
-   */   
+   */
   static createFromCompiler(cachePath, compiler, fileChangeCache, readOnlyMode=false) {
     let newCachePath = null;
     let getCachePath = () => {
@@ -63,20 +63,20 @@ export default class CompileCache {
 
       d(`Path for ${digestObj.name}: ${newCachePath}`);
       d(`Set up with parameters: ${JSON.stringify(digestObj)}`);
-      
+
       if (!readOnlyMode) mkdirp.sync(newCachePath);
       return newCachePath;
     };
-    
+
     let ret = new CompileCache('', fileChangeCache);
     ret.getCachePath = getCachePath;
-    
+
     return ret;
   }
-  
-  /**  
+
+  /**
    * Returns a file's compiled contents from the cache.
-   *    
+   *
    * @param  {string} filePath  The path to the file. FileChangedCache will look
    *                            up the hash and use that as the key in the cache.
    *
@@ -86,29 +86,30 @@ export default class CompileCache {
    * @property {string} code  The source code if the file was a text file
    * @property {Buffer} binaryData  The file if it was a binary file
    * @property {string} mimeType  The MIME type saved in the cache.
-   * @property {string[]} dependentFiles  The dependent files returned from 
+   * @property {string[]} dependentFiles  The dependent files returned from
    *                                      compiling the file, if any.
-   */   
+   */
   async get(filePath) {
-    d(`Fetching ${filePath} from cache`);
+    //d(`Fetching ${filePath} from cache`);
     let hashInfo = await this.fileChangeCache.getHashForPath(path.resolve(filePath));
-  
+
     let code = null;
     let mimeType = null;
     let binaryData = null;
     let dependentFiles = null;
-    
+
     let cacheFile = null;
     try {
       cacheFile = path.join(this.getCachePath(), hashInfo.hash);
       let result = null;
+      console.log(filePath, cacheFile);
 
       if (hashInfo.isFileBinary) {
         d("File is binary, reading out info");
         let info = JSON.parse(await pfs.readFile(cacheFile + '.info'));
         mimeType = info.mimeType;
         dependentFiles = info.dependentFiles;
-        
+
         binaryData = hashInfo.binaryData;
         if (!binaryData) {
           binaryData = await pfs.readFile(cacheFile);
@@ -126,15 +127,15 @@ export default class CompileCache {
     } catch (e) {
       d(`Failed to read cache for ${filePath}, looked in ${cacheFile}: ${e.message}`);
     }
-    
+
     return { hashInfo, code, mimeType, binaryData, dependentFiles };
   }
 
-  
-  /**  
+
+  /**
    * Saves a compiled result to cache
-   *    
-   * @param  {Object} hashInfo  The hash information returned from getHashForPath   
+   *
+   * @param  {Object} hashInfo  The hash information returned from getHashForPath
    *
    * @param  {string / Buffer} codeOrBinaryData   The file's contents, either as
    *                                              a string or a Buffer.
@@ -143,33 +144,33 @@ export default class CompileCache {
    * @param  {string[]} dependentFiles  The list of dependent files returned by
    *                                    the compiler.
    * @return {Promise}  Completion.
-   */   
+   */
   async save(hashInfo, codeOrBinaryData, mimeType, dependentFiles) {
     let buf = null;
     let target = path.join(this.getCachePath(), hashInfo.hash);
     d(`Saving to ${target}`);
-    
+
     if (hashInfo.isFileBinary) {
       buf = await pzlib.gzip(codeOrBinaryData);
       await pfs.writeFile(target + '.info', JSON.stringify({mimeType, dependentFiles}), 'utf8');
     } else {
       buf = await pzlib.gzip(new Buffer(JSON.stringify({code: codeOrBinaryData, mimeType, dependentFiles})));
     }
-    
+
     await pfs.writeFile(target, buf);
   }
-  
-  /**  
+
+  /**
    * Attempts to first get a key via {@link get}, then if it fails, call a method
    * to retrieve the contents, then save the result to cache.
-   * 
+   *
    * The fetcher parameter is expected to have the signature:
-   * 
+   *
    * Promise<Object> fetcher(filePath : string, hashInfo : Object);
-   * 
+   *
    * hashInfo is a value returned from getHashForPath
    * The return value of fetcher must be an Object with the properties:
-   * 
+   *
    * mimeType - the MIME type of the data to save
    * code (optional) - the source code as a string, if file is text
    * binaryData (optional) - the file contents as a Buffer, if file is binary
@@ -180,43 +181,43 @@ export default class CompileCache {
    *
    * @param  {Function} fetcher  A method which conforms to the description above.
    *
-   * @return {Promise<Object>}  An Object which has the same fields as the 
+   * @return {Promise<Object>}  An Object which has the same fields as the
    *                            {@link get} method return result.
-   */   
+   */
   async getOrFetch(filePath, fetcher) {
     let cacheResult = await this.get(filePath);
     if (cacheResult.code || cacheResult.binaryData) return cacheResult;
-    
+
     let result = await fetcher(filePath, cacheResult.hashInfo) || { hashInfo: cacheResult.hashInfo };
-    
+
     if (result.mimeType && !cacheResult.hashInfo.isInNodeModules) {
       d(`Cache miss: saving out info for ${filePath}`);
       await this.save(cacheResult.hashInfo, result.code || result.binaryData, result.mimeType, result.dependentFiles);
     }
-    
+
     result.hashInfo = cacheResult.hashInfo;
     return result;
   }
-  
+
   getSync(filePath) {
     d(`Fetching ${filePath} from cache`);
     let hashInfo = this.fileChangeCache.getHashForPathSync(path.resolve(filePath));
-  
+
     let code = null;
     let mimeType = null;
     let binaryData = null;
     let dependentFiles = null;
-    
+
     try {
       let cacheFile = path.join(this.getCachePath(), hashInfo.hash);
-      
+
       let result = null;
       if (hashInfo.isFileBinary) {
         d("File is binary, reading out info");
         let info = JSON.parse(fs.readFileSync(cacheFile + '.info'));
         mimeType = info.mimeType;
         dependentFiles = info.dependentFiles;
-        
+
         binaryData = hashInfo.binaryData;
         if (!binaryData) {
           binaryData = fs.readFileSync(cacheFile);
@@ -234,7 +235,7 @@ export default class CompileCache {
     } catch (e) {
       d(`Failed to read cache for ${filePath}`);
     }
-    
+
     return { hashInfo, code, mimeType, binaryData, dependentFiles };
   }
 
@@ -242,52 +243,52 @@ export default class CompileCache {
     let buf = null;
     let target = path.join(this.getCachePath(), hashInfo.hash);
     d(`Saving to ${target}`);
-    
+
     if (hashInfo.isFileBinary) {
       buf = zlib.gzipSync(codeOrBinaryData);
       fs.writeFileSync(target + '.info', JSON.stringify({mimeType, dependentFiles}), 'utf8');
     } else {
       buf = zlib.gzipSync(new Buffer(JSON.stringify({code: codeOrBinaryData, mimeType, dependentFiles})));
     }
-    
+
     fs.writeFileSync(target, buf);
   }
-  
+
   getOrFetchSync(filePath, fetcher) {
     let cacheResult = this.getSync(filePath);
     if (cacheResult.code || cacheResult.binaryData) return cacheResult;
-    
+
     let result = fetcher(filePath, cacheResult.hashInfo) || { hashInfo: cacheResult.hashInfo };
-    
+
     if (result.mimeType && !cacheResult.hashInfo.isInNodeModules) {
       d(`Cache miss: saving out info for ${filePath}`);
       this.saveSync(cacheResult.hashInfo, result.code || result.binaryData, result.mimeType, result.dependentFiles);
     }
-    
+
     result.hashInfo = cacheResult.hashInfo;
     return result;
   }
-  
-  
-  /**  
+
+
+  /**
    * @private
-   */   
+   */
   getCachePath() {
     // NB: This is an evil hack so that createFromCompiler can stomp it
     // at will
     return this.cachePath;
   }
-    
-    
-  /**    
-   * Returns whether a file should not be compiled. Note that this doesn't 
+
+
+  /**
+   * Returns whether a file should not be compiled. Note that this doesn't
    * necessarily mean it won't end up in the cache, only that its contents are
    * saved verbatim instead of trying to find an appropriate compiler.
-   *    
-   * @param  {Object} hashInfo  The hash information returned from getHashForPath   
+   *
+   * @param  {Object} hashInfo  The hash information returned from getHashForPath
    *
    * @return {boolean}  True if a file should be ignored
-   */   
+   */
   static shouldPassthrough(hashInfo) {
     return hashInfo.isMinified || hashInfo.isInNodeModules || hashInfo.hasSourceMap || hashInfo.isFileBinary;
   }

--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -19,7 +19,7 @@ function statSyncNoException(fsPath) {
   if ('statSyncNoException' in fs) {
     return fs.statSyncNoException(fsPath);
   }
-  
+
   try {
     return fs.statSync(fsPath);
   } catch (e) {
@@ -29,13 +29,13 @@ function statSyncNoException(fsPath) {
 
 
 /**
- * Initialize the global hooks (protocol hook for file:, node.js hook) 
+ * Initialize the global hooks (protocol hook for file:, node.js hook)
  * independent of initializing the compiler. This method is usually called by
  * init instead of directly
- * 
+ *
  * @param {CompilerHost} compilerHost  The compiler host to use.
- *  
- */ 
+ *
+ */
 export function initializeGlobalHooks(compilerHost) {
   let globalVar = (global || window);
   globalVar.globalCompilerHost = compilerHost;
@@ -44,7 +44,7 @@ export function initializeGlobalHooks(compilerHost) {
 
   if ('type' in process && process.type === 'browser') {
     const { app } = require('electron');
-    
+
     let protoify = function() { initializeProtocolHook(compilerHost); };
     if (app.isReady()) {
       protoify();
@@ -56,37 +56,47 @@ export function initializeGlobalHooks(compilerHost) {
 
 
 /**
- * Initialize electron-compile and set it up, either for development or 
+ * Initialize electron-compile and set it up, either for development or
  * production use. This is almost always the only method you need to use in order
  * to use electron-compile.
- *  
+ *
  * @param  {string} appRoot  The top-level directory for your application (i.e.
  *                           the one which has your package.json).
  *
  * @param  {string} mainModule  The module to require in, relative to the module
- *                              calling init, that will start your app. Write this 
+ *                              calling init, that will start your app. Write this
  *                              as if you were writing a require call from here.
  *
  * @param  {bool} productionMode   If explicitly True/False, will set read-only
  *                                 mode to be disabled/enabled. If not, we'll
  *                                 guess based on the presence of a production
  *                                 cache.
- */ 
-export function init(appRoot, mainModule, productionMode = null) {
+ *
+ * @param  {string} cacheDir  If not passed in, read-only will look in
+ *                            `appRoot/.cache` and dev mode will compile to a
+ *                            temporary directory. If it is passed in, both modes
+ *                            will cache to/from `appRoot/{cacheDir}`
+ */
+export function init(appRoot, mainModule, productionMode = null, cacheDir = null) {
   let compilerHost = null;
-  let cacheDir = path.join(appRoot, '.cache');
-  
+  let rootCacheDir = path.join(appRoot, cacheDir || '.cache');
+
   if (productionMode === null) {
-    productionMode = !!statSyncNoException(cacheDir);
+    productionMode = !!statSyncNoException(rootCacheDir);
   }
-  
+
   if (productionMode) {
-    // In read-only mode, we'll assume that everything is in `appRoot/.cache`
-    compilerHost = CompilerHost.createReadonlyFromConfigurationSync(cacheDir, appRoot);
+    compilerHost = CompilerHost.createReadonlyFromConfigurationSync(rootCacheDir, appRoot);
   } else {
-    compilerHost = createCompilerHostFromProjectRootSync(appRoot);
+    // if cacheDir was passed in, pass it along. Otherwise, default to a tempdir.
+    if (cacheDir) {
+      compilerHost = createCompilerHostFromProjectRootSync(appRoot, rootCacheDir);
+    } else {
+      compilerHost = createCompilerHostFromProjectRootSync(appRoot);  
+    }
+
   }
-  
+
   initializeGlobalHooks(compilerHost);
   require.main.require(mainModule);
 }
@@ -95,27 +105,27 @@ export function init(appRoot, mainModule, productionMode = null) {
 /**
  * Creates a {@link CompilerHost} with the given information. This method is
  * usually called by {@link createCompilerHostFromProjectRoot}.
- *  
+ *
  * @private
- */ 
+ */
 export function createCompilerHostFromConfiguration(info) {
   let compilers = createCompilers();
   let rootCacheDir = info.rootCacheDir || calculateDefaultCompileCacheDirectory();
-  
+
   d(`Creating CompilerHost: ${JSON.stringify(info)}, rootCacheDir = ${rootCacheDir}`);
   let fileChangeCache = new FileChangedCache(info.appRoot);
   let ret = new CompilerHost(rootCacheDir, compilers, fileChangeCache, false, compilers['text/plain']);
-  
+
   _.each(Object.keys(info.options || {}), (x) => {
     let opts = info.options[x];
     if (!(x in compilers)) {
       throw new Error(`Found compiler settings for missing compiler: ${x}`);
     }
-    
+
     d(`Setting options for ${x}: ${JSON.stringify(opts)}`);
     compilers[x].compilerOptions = opts;
   });
-  
+
   // NB: It's super important that we guarantee that the configuration is saved
   // out, because we'll need to re-read it in the renderer process
   d(`Created compiler host with options: ${JSON.stringify(info)}`);
@@ -126,26 +136,26 @@ export function createCompilerHostFromConfiguration(info) {
 /**
  * Creates a compiler host from a .babelrc file. This method is usually called
  * from {@link createCompilerHostFromProjectRoot} instead of used directly.
- *  
+ *
  * @param  {string} file  The path to a .babelrc file
  *
  * @param  {string} rootCacheDir (optional)  The directory to use as a cache.
  *
  * @return {Promise<CompilerHost>}  A set-up compiler host
- */ 
+ */
 export async function createCompilerHostFromBabelRc(file, rootCacheDir=null) {
   let info = JSON.parse(await pfs.readFile(file, 'utf8'));
-  
+
   // package.json
   if ('babel' in info) {
     info = info.babel;
   }
-  
+
   if ('env' in info) {
     let ourEnv = process.env.BABEL_ENV || process.env.NODE_ENV || 'development';
     info = info.env[ourEnv];
   }
-  
+
   // Are we still package.json (i.e. is there no babel info whatsoever?)
   if ('name' in info && 'version' in info) {
     return createCompilerHostFromConfiguration({
@@ -154,7 +164,7 @@ export async function createCompilerHostFromBabelRc(file, rootCacheDir=null) {
       rootCacheDir
     });
   }
-  
+
   return createCompilerHostFromConfiguration({
     appRoot: path.dirname(file),
     options: {
@@ -168,21 +178,21 @@ export async function createCompilerHostFromBabelRc(file, rootCacheDir=null) {
 /**
  * Creates a compiler host from a .compilerc file. This method is usually called
  * from {@link createCompilerHostFromProjectRoot} instead of used directly.
- *  
+ *
  * @param  {string} file  The path to a .compilerc file
  *
  * @param  {string} rootCacheDir (optional)  The directory to use as a cache.
  *
  * @return {Promise<CompilerHost>}  A set-up compiler host
- */ 
+ */
 export async function createCompilerHostFromConfigFile(file, rootCacheDir=null) {
   let info = JSON.parse(await pfs.readFile(file, 'utf8'));
-  
+
   if ('env' in info) {
     let ourEnv = process.env.ELECTRON_COMPILE_ENV || process.env.NODE_ENV || 'development';
     info = info.env[ourEnv];
   }
-  
+
   return createCompilerHostFromConfiguration({
     appRoot: path.dirname(file),
     options: info,
@@ -192,48 +202,48 @@ export async function createCompilerHostFromConfigFile(file, rootCacheDir=null) 
 
 
 /**
- * Creates a configured {@link CompilerHost} instance from the project root 
+ * Creates a configured {@link CompilerHost} instance from the project root
  * directory. This method first searches for a .compilerc, then falls back to the
  * default locations for Babel configuration info. If neither are found, defaults
  * to standard settings
- *  
+ *
  * @param  {string} rootDir  The root application directory (i.e. the directory
  *                           that has the app's package.json)
  *
  * @param  {string} rootCacheDir (optional)  The directory to use as a cache.
  *
  * @return {Promise<CompilerHost>}  A set-up compiler host
- */ 
+ */
 export async function createCompilerHostFromProjectRoot(rootDir, rootCacheDir=null) {
   let compilerc = path.join(rootDir, '.compilerc');
   if (statSyncNoException(compilerc)) {
     d(`Found a .compilerc at ${compilerc}, using it`);
     return await createCompilerHostFromConfigFile(compilerc, rootCacheDir);
   }
-  
+
   let babelrc = path.join(rootDir, '.babelrc');
   if (statSyncNoException(babelrc)) {
     d(`Found a .babelrc at ${babelrc}, using it`);
     return await createCompilerHostFromBabelRc(babelrc, rootCacheDir);
   }
-    
+
   d(`Using package.json or default parameters at ${rootDir}`);
   return await createCompilerHostFromBabelRc(path.join(rootDir, 'package.json'), rootCacheDir);
 }
 
 export function createCompilerHostFromBabelRcSync(file, rootCacheDir=null) {
   let info = JSON.parse(fs.readFileSync(file, 'utf8'));
-  
+
   // package.json
   if ('babel' in info) {
     info = info.babel;
   }
-  
+
   if ('env' in info) {
     let ourEnv = process.env.BABEL_ENV || process.env.NODE_ENV || 'development';
     info = info.env[ourEnv];
   }
-  
+
   // Are we still package.json (i.e. is there no babel info whatsoever?)
   if ('name' in info && 'version' in info) {
     return createCompilerHostFromConfiguration({
@@ -242,7 +252,7 @@ export function createCompilerHostFromBabelRcSync(file, rootCacheDir=null) {
       rootCacheDir
     });
   }
-  
+
   return createCompilerHostFromConfiguration({
     appRoot: path.dirname(file),
     options: {
@@ -254,12 +264,12 @@ export function createCompilerHostFromBabelRcSync(file, rootCacheDir=null) {
 
 export function createCompilerHostFromConfigFileSync(file, rootCacheDir=null) {
   let info = JSON.parse(fs.readFileSync(file, 'utf8'));
-  
+
   if ('env' in info) {
     let ourEnv = process.env.ELECTRON_COMPILE_ENV || process.env.NODE_ENV || 'development';
     info = info.env[ourEnv];
   }
-  
+
   return createCompilerHostFromConfiguration({
     appRoot: path.dirname(file),
     options: info,
@@ -273,13 +283,13 @@ export function createCompilerHostFromProjectRootSync(rootDir, rootCacheDir=null
     d(`Found a .compilerc at ${compilerc}, using it`);
     return createCompilerHostFromConfigFileSync(compilerc, rootCacheDir);
   }
-  
+
   let babelrc = path.join(rootDir, '.babelrc');
   if (statSyncNoException(babelrc)) {
     d(`Found a .babelrc at ${babelrc}, using it`);
     return createCompilerHostFromBabelRcSync(babelrc, rootCacheDir);
   }
-    
+
   d(`Using package.json or default parameters at ${rootDir}`);
   return createCompilerHostFromBabelRcSync(path.join(rootDir, 'package.json'), rootCacheDir);
 }
@@ -287,17 +297,17 @@ export function createCompilerHostFromProjectRootSync(rootDir, rootCacheDir=null
 /**
  * Returns what electron-compile would use as a default rootCacheDir. Usually only
  * used for debugging purposes
- *  
+ *
  * @return {string}  A path that may or may not exist where electron-compile would
  *                   set up a development mode cache.
- */ 
+ */
 export function calculateDefaultCompileCacheDirectory() {
   let tmpDir = process.env.TEMP || process.env.TMPDIR || '/tmp';
   let hash = require('crypto').createHash('md5').update(process.execPath).digest('hex');
 
   let cacheDir = path.join(tmpDir, `compileCache_${hash}`);
   mkdirp.sync(cacheDir);
-  
+
   d(`Using default cache directory: ${cacheDir}`);
   return cacheDir;
 }
@@ -305,9 +315,9 @@ export function calculateDefaultCompileCacheDirectory() {
 
 /**
  * Returns the default .configrc if no configuration information can be found.
- *  
+ *
  * @return {Object}  A list of default config settings for electron-compiler.
- */ 
+ */
 export function getDefaultConfiguration() {
   return {
     'application/javascript': {
@@ -318,13 +328,13 @@ export function getDefaultConfiguration() {
 }
 
 /**
- * Allows you to create new instances of all compilers that are supported by 
- * electron-compile and use them directly. Currently supports Babel, CoffeeScript, 
+ * Allows you to create new instances of all compilers that are supported by
+ * electron-compile and use them directly. Currently supports Babel, CoffeeScript,
  * TypeScript, LESS, and Jade.
- *  
- * @return {Object}  An Object whose Keys are MIME types, and whose values 
+ *
+ * @return {Object}  An Object whose Keys are MIME types, and whose values
  * are instances of @{link CompilerBase}.
- */ 
+ */
 export function createCompilers() {
   if (!allCompilerClasses) {
     // First we want to see if electron-compilers itself has been installed with
@@ -346,7 +356,7 @@ export function createCompilers() {
     }
   }
 
-  // NB: Note that this code is carefully set up so that InlineHtmlCompiler 
+  // NB: Note that this code is carefully set up so that InlineHtmlCompiler
   // (i.e. classes with `createFromCompilers`) initially get an empty object,
   // but will have a reference to the final result of what we return, which
   // resolves the circular dependency we'd otherwise have here.
@@ -365,6 +375,6 @@ export function createCompilers() {
     for (let type of Klass.getInputMimeTypes()) { acc[type] = x; }
     return acc;
   }, ret);
-  
+
   return ret;
 }


### PR DESCRIPTION
Just allows you to customize the cachedir. The way I wrote it, If you pass a cachedir explicitly it will use it for both production mode and for development. 

Takes care of #83 