### PR TITLE
Use small MimeDB

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-compile",
-  "version": "2.1.4",
+  "version": "3.0.0",
   "description": "Electron supporting package to compile JS and CSS in Electron applications",
   "scripts": {
     "doc": "esdoc -c ./esdoc.json",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "chai": "^3.4.1",
     "chai-as-promised": "^5.2.0",
     "cheerio": "^0.19.0",
-    "electron-compilers": "^2.1.4",
+    "electron-compilers": "^3.0.0",
     "electron-prebuilt": "^0.36.2",
     "esdoc": "^0.4.3",
     "esdoc-es7-plugin": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "debug": "^2.2.0",
     "lodash": "^3.10.1",
     "lru-cache": "^4.0.0",
-    "mime-types": "^2.1.8",
+    "@paulcbetts/mime-types": "^2.1.8",
     "mkdirp": "^0.5.1",
     "pify": "^2.3.0",
     "yargs": "^3.31.0"

--- a/src/compiler-host.js
+++ b/src/compiler-host.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import mimeTypes from 'mime-types';
+import mimeTypes from '@paulcbetts/mime-types';
 import fs from 'fs';
 import zlib from 'zlib';
 import path from 'path';

--- a/src/protocol-hook.js
+++ b/src/protocol-hook.js
@@ -1,7 +1,7 @@
 import './babel-maybefill';
 import url from 'url';
 import fs from 'fs';
-import mime from 'mime-types';
+import mime from '@paulcbetts/mime-types';
 
 import CompilerHost from './compiler-host';
 

--- a/src/require-hook.js
+++ b/src/require-hook.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import mimeTypes from 'mime-types';
+import mimeTypes from '@paulcbetts/mime-types';
 
 /**
  * Initializes the node.js hook that allows us to intercept files loaded by 

--- a/src/rig-mime-types.js
+++ b/src/rig-mime-types.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import mimeTypes from 'mime-types';
+import mimeTypes from '@paulcbetts/mime-types';
 
 const typesToRig = {
   'text/typescript': 'ts',

--- a/test/compiler-host.js
+++ b/test/compiler-host.js
@@ -5,7 +5,7 @@ import path from 'path';
 import fs from 'fs';
 import rimraf from 'rimraf';
 import mkdirp from 'mkdirp';
-import mimeTypes from 'mime-types';
+import mimeTypes from '@paulcbetts/mime-types';
 import FileChangeCache from '../src/file-change-cache';
 import CompilerHost from '../src/compiler-host';
 

--- a/test/compiler-valid-invalid.js
+++ b/test/compiler-valid-invalid.js
@@ -4,7 +4,7 @@ import pify from 'pify';
 import fs from 'fs';
 import path from 'path';
 import _ from 'lodash';
-import mimeTypes from 'mime-types';
+import mimeTypes from '@paulcbetts/mime-types';
 
 const pfs = pify(fs);
 


### PR DESCRIPTION
electron-compile uses `mime-types` which uses `mime-db` - this database is one giant JSON file that takes up a lot of memory in Electron apps. Instead we'll use paulcbetts/mime-db which is the same thing only it strips out filetypes that aren't interesting to browsers. 

Even though this is a pretty boring change, this could potentially break things (especially if you had an old version of electron-compilers and a new version of electron-compile, or vice-versa), so we're going to major version bump