### PR TITLE
The link was broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,4 +154,4 @@ electron-compile --appDir /path/to/my/app ./src ./static
 
 ### But I use Grunt / Gulp / I want to do Something Interesting
 
-Compilation also has its own API, check out the [documentation](http://electronjs.github.io/electron-compile/docs/) for more information.
+Compilation also has its own API, check out the [documentation](http://electron.github.io/electron-compile/docs/) for more information.


### PR DESCRIPTION
The github page is under electron, not electronjs