### PR TITLE
Remove toLowerCase() on return from sanitize-paths.js

### DIFF
--- a/src/sanitize-paths.js
+++ b/src/sanitize-paths.js
@@ -42,6 +42,5 @@ export default function sanitizeFilePath(file) {
     realFile = `${cachedRealpath(parts[0])}/app.asar/${parts[1]}`;
   }
 
-  let ret = realFile.replace(/[\\\/]/g, '/');
-  return ret.toLowerCase();
+  return realFile.replace(/[\\\/]/g, '/');
 }


### PR DESCRIPTION
Fixes issue #73.

Also tried the latest version @3.1.0 on Windows and it works due to Windows not caring about upper/lower case paths while Linux fails with ENOENT. I can't test on OS X (don't own a Mac) but I'm assuming it would fail as well if there are any capital letters in the path.

Ran mocha tests and all 63 pass in 9s, same as before removing toLowerCase().