### PR TITLE
Clarify "How does it work?" documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For JSON:
 
 ### How does it work? (Easiest Way)
 
-Change your reference to `electron-prebuilt` to `electron-prebuilt-compile`. Tada! You did it.
+Use `electron-prebuilt-compile` instead of the `electron-prebuilt` module. Tada! You did it.
 
 ### Wait, seriously?
 


### PR DESCRIPTION
As far as I can tell 'reference' is not a standard term when discussing a package.json dependency. I found it very unclear which reference was being referred to. 

Additionally, this documentation is particularly odd, because it is an npm module for which the opening line is suggesting to install another module (albeit one that uses this one).  

For these reasons I am suggesting to make it explicitly clear that the user is expected to switch out the modules. 