### PR TITLE
add node modules sourceMapping resolution

### DIFF
--- a/src/compiler-host.js
+++ b/src/compiler-host.js
@@ -609,7 +609,7 @@ export default class CompilerHost {
    * @private
    */
   static fixNodeModulesSourceMapping(sourceCode, sourcePath, appRoot) {
-    let regexSourceMapping = /\/\/#.+sourceMappingURL=(.*)/i;
+    let regexSourceMapping = /\/\/#.*sourceMappingURL=([^"'].*)/i;
     let sourceMappingCheck = sourceCode.match(regexSourceMapping);
 
     if (sourceMappingCheck && sourceMappingCheck[1] && sourceMappingCheck[1] !== ''){

--- a/src/compiler-host.js
+++ b/src/compiler-host.js
@@ -609,7 +609,7 @@ export default class CompilerHost {
    * @private
    */
   static fixNodeModulesSourceMapping(sourceCode, sourcePath, appRoot) {
-    let regexSourceMapping = /\/\/#.*sourceMappingURL=([^"'].*)/i;
+    let regexSourceMapping = /\/\/#.*sourceMappingURL=(?!data:)([^"'].*)/i;
     let sourceMappingCheck = sourceCode.match(regexSourceMapping);
 
     if (sourceMappingCheck && sourceMappingCheck[1] && sourceMappingCheck[1] !== ''){

--- a/src/compiler-host.js
+++ b/src/compiler-host.js
@@ -23,38 +23,38 @@ const finalForms = {
 };
 
 /**
- * This class is the top-level class that encapsulates all of the logic of 
+ * This class is the top-level class that encapsulates all of the logic of
  * compiling and caching application code. If you're looking for a "Main class",
  * this is it.
- * 
+ *
  * This class can be created directly but it is usually created via the methods
  * in config-parser, which will among other things, set up the compiler options
  * given a project root.
- * 
+ *
  * CompilerHost is also the top-level class that knows how to serialize all of the
  * information necessary to recreate itself, either as a development host (i.e.
  * will allow cache misses and actual compilation), or as a read-only version of
  * itself for production.
- */ 
+ */
 export default class CompilerHost {
-  /**  
+  /**
    * Creates an instance of CompilerHost. You probably want to use the methods
    * in config-parser for development, or {@link createReadonlyFromConfiguration}
    * for production instead.
-   *    
+   *
    * @param  {string} rootCacheDir  The root directory to use for the cache
-   * 
+   *
    * @param  {Object} compilers  an Object whose keys are input MIME types and
    *                             whose values are instances of CompilerBase. Create
    *                             this via the {@link createCompilers} method in
    *                             config-parser.
-   * 
-   * @param  {FileChangedCache} fileChangeCache  A file-change cache that is 
+   *
+   * @param  {FileChangedCache} fileChangeCache  A file-change cache that is
    *                                             optionally pre-loaded.
-   * 
-   * @param  {boolean} readOnlyMode  If True, cache misses will fail and 
+   *
+   * @param  {boolean} readOnlyMode  If True, cache misses will fail and
    *                                 compilation will not be attempted.
-   * 
+   *
    * @param  {CompilerBase} fallbackCompiler (optional)  When a file is compiled
    *                                         which doesn't have a matching compiler,
    *                                         this compiler will be used instead. If
@@ -62,27 +62,27 @@ export default class CompilerHost {
    *                                         alternate fallback is the compiler for
    *                                         'text/plain', which is guaranteed to be
    *                                         present.
-   */   
+   */
   constructor(rootCacheDir, compilers, fileChangeCache, readOnlyMode, fallbackCompiler = null) {
     let compilersByMimeType = _.assign({}, compilers);
     _.assign(this, {rootCacheDir, compilersByMimeType, fileChangeCache, readOnlyMode, fallbackCompiler});
     this.appRoot = this.fileChangeCache.appRoot;
-    
+
     this.cachesForCompilers = _.reduce(Object.keys(compilersByMimeType), (acc, x) => {
       let compiler = compilersByMimeType[x];
       if (acc.has(compiler)) return acc;
 
       acc.set(
-        compiler, 
+        compiler,
         CompileCache.createFromCompiler(rootCacheDir, compiler, fileChangeCache, readOnlyMode));
       return acc;
     }, new Map());
   }
-    
-  /**    
-   * Creates a production-mode CompilerHost from the previously saved 
+
+  /**
+   * Creates a production-mode CompilerHost from the previously saved
    * configuration
-   *    
+   *
    * @param  {string} rootCacheDir  The root directory to use for the cache. This
    *                                cache must have cache information saved via
    *                                {@link saveConfiguration}
@@ -96,31 +96,31 @@ export default class CompilerHost {
    *                                         null, will fail compilation. A good
    *                                         alternate fallback is the compiler for
    *                                         'text/plain', which is guaranteed to be
-   *                                         present. 
+   *                                         present.
    *
    * @return {Promise<CompilerHost>}  A read-only CompilerHost
-   */   
+   */
   static async createReadonlyFromConfiguration(rootCacheDir, appRoot, fallbackCompiler=null) {
     let target = path.join(rootCacheDir, 'compiler-info.json.gz');
     let buf = await pfs.readFile(target);
     let info = JSON.parse(await pzlib.gunzip(buf));
-    
+
     let fileChangeCache = FileChangedCache.loadFromData(info.fileChangeCache, appRoot, true);
 
     let compilers = _.reduce(Object.keys(info.compilers), (acc, x) => {
       let cur = info.compilers[x];
       acc[x] = new ReadOnlyCompiler(cur.name, cur.compilerVersion, cur.compilerOptions, cur.inputMimeTypes);
-      
+
       return acc;
     }, {});
-    
+
     return new CompilerHost(rootCacheDir, compilers, fileChangeCache, true, fallbackCompiler);
   }
 
-  /**    
-   * Creates a development-mode CompilerHost from the previously saved 
+  /**
+   * Creates a development-mode CompilerHost from the previously saved
    * configuration.
-   *    
+   *
    * @param  {string} rootCacheDir  The root directory to use for the cache. This
    *                                cache must have cache information saved via
    *                                {@link saveConfiguration}
@@ -128,74 +128,74 @@ export default class CompilerHost {
    * @param  {string} appRoot  The top-level directory for your application (i.e.
    *                           the one which has your package.json).
    *
-   * @param  {Object} compilersByMimeType  an Object whose keys are input MIME 
-   *                                       types and whose values are instances 
-   *                                       of CompilerBase. Create this via the 
-   *                                       {@link createCompilers} method in 
+   * @param  {Object} compilersByMimeType  an Object whose keys are input MIME
+   *                                       types and whose values are instances
+   *                                       of CompilerBase. Create this via the
+   *                                       {@link createCompilers} method in
    *                                       config-parser.
-   * 
+   *
    * @param  {CompilerBase} fallbackCompiler (optional)  When a file is compiled
    *                                         which doesn't have a matching compiler,
    *                                         this compiler will be used instead. If
    *                                         null, will fail compilation. A good
    *                                         alternate fallback is the compiler for
    *                                         'text/plain', which is guaranteed to be
-   *                                         present. 
+   *                                         present.
    *
    * @return {Promise<CompilerHost>}  A read-only CompilerHost
-   */   
+   */
   static async createFromConfiguration(rootCacheDir, appRoot, compilersByMimeType, fallbackCompiler=null) {
     let target = path.join(rootCacheDir, 'compiler-info.json.gz');
     let buf = await pfs.readFile(target);
     let info = JSON.parse(await pzlib.gunzip(buf));
-    
+
     let fileChangeCache = FileChangedCache.loadFromData(info.fileChangeCache, appRoot, false);
-    
+
     _.each(Object.keys(info.compilers), (x) => {
       let cur = info.compilers[x];
       compilersByMimeType[x].compilerOptions = cur.compilerOptions;
     });
-    
+
     return new CompilerHost(rootCacheDir, compilersByMimeType, fileChangeCache, false, fallbackCompiler);
   }
-  
-  
-  /**  
-   * Saves the current compiler configuration to a file that 
-   * {@link createReadonlyFromConfiguration} can use to recreate the current 
+
+
+  /**
+   * Saves the current compiler configuration to a file that
+   * {@link createReadonlyFromConfiguration} can use to recreate the current
    * compiler environment
-   *    
+   *
    * @return {Promise}  Completion
-   */   
+   */
   async saveConfiguration() {
     let serializedCompilerOpts = _.reduce(Object.keys(this.compilersByMimeType), (acc, x) => {
       let compiler = this.compilersByMimeType[x];
       let Klass = Object.getPrototypeOf(compiler).constructor;
-      
+
       let val = {
         name: Klass.name,
         inputMimeTypes: Klass.getInputMimeTypes(),
         compilerOptions: compiler.compilerOptions,
         compilerVersion: compiler.getCompilerVersion()
       };
-      
+
       acc[x] = val;
       return acc;
     }, {});
-    
+
     let info = {
       fileChangeCache: this.fileChangeCache.getSavedData(),
       compilers: serializedCompilerOpts
     };
-    
+
     let target = path.join(this.rootCacheDir, 'compiler-info.json.gz');
     let buf = await pzlib.gzip(new Buffer(JSON.stringify(info)));
     await pfs.writeFile(target, buf);
   }
-  
-  /**  
+
+  /**
    * Compiles a file and returns the compiled result.
-   *    
+   *
    * @param  {string} filePath  The path to the file to compile
    *
    * @return {Promise<object>}  An Object with the compiled result
@@ -204,29 +204,29 @@ export default class CompilerHost {
    * @property {string} code  The source code if the file was a text file
    * @property {Buffer} binaryData  The file if it was a binary file
    * @property {string} mimeType  The MIME type saved in the cache.
-   * @property {string[]} dependentFiles  The dependent files returned from 
+   * @property {string[]} dependentFiles  The dependent files returned from
    *                                      compiling the file, if any.
-   */   
+   */
   compile(filePath) {
     return (this.readOnlyMode ? this.compileReadOnly(filePath) : this.fullCompile(filePath));
   }
-  
-  
-  /**  
+
+
+  /**
    * Handles compilation in read-only mode
    *
    * @private
-   */   
+   */
   async compileReadOnly(filePath) {
     // We guarantee that node_modules are always shipped directly
     let type = mimeTypes.lookup(filePath);
     if (FileChangedCache.isInNodeModules(filePath)) {
-      return { 
+      return {
         mimeType: type || 'application/javascript',
-        code: await pfs.readFile(filePath, 'utf8') 
-      };    
+        code: await pfs.readFile(filePath, 'utf8')
+      };
     }
-    
+
     let hashInfo = await this.fileChangeCache.getHashForPath(filePath);
 
     // NB: Here, we're basically only using the compiler here to find
@@ -235,7 +235,7 @@ export default class CompilerHost {
       this.getPassthroughCompiler() :
       this.compilersByMimeType[type || '__lolnothere'];
 
-    if (!compiler) { 
+    if (!compiler) {
       compiler = this.fallbackCompiler;
 
       let { code, binaryData, mimeType } = await compiler.get(filePath);
@@ -253,19 +253,20 @@ export default class CompilerHost {
     return { code, mimeType };
   }
 
-  /**  
+  /**
    * Handles compilation in read-write mode
    *
    * @private
-   */     
+   */
   async fullCompile(filePath) {
     d(`Compiling ${filePath}`);
-    
+
     let hashInfo = await this.fileChangeCache.getHashForPath(filePath);
     let type = mimeTypes.lookup(filePath);
-    
+
     if (hashInfo.isInNodeModules) {
       let code = hashInfo.sourceCode || await pfs.readFile(filePath, 'utf8');
+      code = CompilerHost.fixNodeModulesSourceMapping(code, filePath, this.fileChangeCache.appRoot);
       return { code, mimeType: type };
     }
 
@@ -288,14 +289,14 @@ export default class CompilerHost {
       (filePath, hashInfo) => this.compileUncached(filePath, hashInfo, compiler));
   }
 
-  /**  
+  /**
    * Handles invoking compilers independent of caching
    *
    * @private
    */
   async compileUncached(filePath, hashInfo, compiler) {
     let inputMimeType = mimeTypes.lookup(filePath);
-    
+
     if (hashInfo.isFileBinary) {
       return {
         binaryData: hashInfo.binaryData || await pfs.readFile(filePath),
@@ -303,7 +304,7 @@ export default class CompilerHost {
         dependentFiles: []
       };
     }
-    
+
     let ctx = {};
     let code = hashInfo.sourceCode || await pfs.readFile(filePath, 'utf8');
 
@@ -317,15 +318,15 @@ export default class CompilerHost {
     d(`Using compiler options: ${JSON.stringify(compiler.compilerOptions)}`);
     let result = await compiler.compile(code, filePath, ctx);
 
-    let shouldInlineHtmlify = 
+    let shouldInlineHtmlify =
       inputMimeType !== 'text/html' &&
       result.mimeType === 'text/html';
-    
-    let isPassthrough = 
-      result.mimeType === 'text/plain' || 
-      !result.mimeType || 
+
+    let isPassthrough =
+      result.mimeType === 'text/plain' ||
+      !result.mimeType ||
       CompilerHost.shouldPassthrough(hashInfo);
-      
+
     if ((finalForms[result.mimeType] && !shouldInlineHtmlify) || isPassthrough) {
       // Got something we can use in-browser, let's return it
       return _.assign(result, {dependentFiles});
@@ -342,24 +343,24 @@ export default class CompilerHost {
       }
 
       return await this.compileUncached(
-        `${filePath}.${mimeTypes.extension(result.mimeType || 'txt')}`, 
+        `${filePath}.${mimeTypes.extension(result.mimeType || 'txt')}`,
         hashInfo, compiler);
     }
   }
-  
-  /**  
-   * Pre-caches an entire directory of files recursively. Usually used for 
+
+  /**
+   * Pre-caches an entire directory of files recursively. Usually used for
    * building custom compiler tooling.
-   *    
+   *
    * @param  {string} rootDirectory  The top-level directory to compile
    *
-   * @param  {Function} shouldCompile (optional)  A Function which allows the 
+   * @param  {Function} shouldCompile (optional)  A Function which allows the
    *                                  caller to disable compiling certain files.
    *                                  It takes a fully-qualified path to a file,
    *                                  and should return a Boolean.
    *
    * @return {Promise}  Completion.
-   */   
+   */
   async compileAll(rootDirectory, shouldCompile=null) {
     let should = shouldCompile || function() {return true;};
 
@@ -370,91 +371,91 @@ export default class CompilerHost {
       return this.compile(f, this.compilersByMimeType);
     });
   }
-  
+
   /*
    * Sync Methods
    */
-   
+
   compileSync(filePath) {
     return (this.readOnlyMode ? this.compileReadOnlySync(filePath) : this.fullCompileSync(filePath));
   }
-  
+
   static createReadonlyFromConfigurationSync(rootCacheDir, appRoot, fallbackCompiler=null) {
     let target = path.join(rootCacheDir, 'compiler-info.json.gz');
     let buf = fs.readFileSync(target);
     let info = JSON.parse(zlib.gunzipSync(buf));
-    
+
     let fileChangeCache = FileChangedCache.loadFromData(info.fileChangeCache, appRoot, true);
-    
+
     let compilers = _.reduce(Object.keys(info.compilers), (acc, x) => {
       let cur = info.compilers[x];
       acc[x] = new ReadOnlyCompiler(cur.name, cur.compilerVersion, cur.compilerOptions, cur.inputMimeTypes);
-      
+
       return acc;
     }, {});
-    
+
     return new CompilerHost(rootCacheDir, compilers, fileChangeCache, true, fallbackCompiler);
   }
-  
+
   static createFromConfigurationSync(rootCacheDir, appRoot, compilersByMimeType, fallbackCompiler=null) {
     let target = path.join(rootCacheDir, 'compiler-info.json.gz');
     let buf = fs.readFileSync(target);
     let info = JSON.parse(zlib.gunzipSync(buf));
-    
+
     let fileChangeCache = FileChangedCache.loadFromData(info.fileChangeCache, appRoot, false);
-    
+
     _.each(Object.keys(info.compilers), (x) => {
       let cur = info.compilers[x];
       compilersByMimeType[x].compilerOptions = cur.compilerOptions;
     });
-    
+
     return new CompilerHost(rootCacheDir, compilersByMimeType, fileChangeCache, false, fallbackCompiler);
   }
-   
+
   saveConfigurationSync() {
     let serializedCompilerOpts = _.reduce(Object.keys(this.compilersByMimeType), (acc, x) => {
       let compiler = this.compilersByMimeType[x];
       let Klass = Object.getPrototypeOf(compiler).constructor;
-      
+
       let val = {
         name: Klass.name,
         inputMimeTypes: Klass.getInputMimeTypes(),
         compilerOptions: compiler.compilerOptions,
         compilerVersion: compiler.getCompilerVersion()
       };
-      
+
       acc[x] = val;
       return acc;
     }, {});
-    
+
     let info = {
       fileChangeCache: this.fileChangeCache.getSavedData(),
       compilers: serializedCompilerOpts
     };
-    
+
     let target = path.join(this.rootCacheDir, 'compiler-info.json.gz');
     let buf = zlib.gzipSync(new Buffer(JSON.stringify(info)));
     fs.writeFileSync(target, buf);
   }
-  
+
   compileReadOnlySync(filePath) {
     // We guarantee that node_modules are always shipped directly
     let type = mimeTypes.lookup(filePath);
     if (FileChangedCache.isInNodeModules(filePath)) {
-      return { 
+      return {
         mimeType: type || 'application/javascript',
-        code: fs.readFileSync(filePath, 'utf8') 
-      };    
-    }  
+        code: fs.readFileSync(filePath, 'utf8')
+      };
+    }
 
     let hashInfo = this.fileChangeCache.getHashForPathSync(filePath);
-    
+
     // We guarantee that node_modules are always shipped directly
     if (hashInfo.isInNodeModules) {
-      return { 
-        mimeType: type, 
-        code: hashInfo.sourceCode || fs.readFileSync(filePath, 'utf8') 
-      };    
+      return {
+        mimeType: type,
+        code: hashInfo.sourceCode || fs.readFileSync(filePath, 'utf8')
+      };
     }
 
     // NB: Here, we're basically only using the compiler here to find
@@ -463,7 +464,7 @@ export default class CompilerHost {
       this.getPassthroughCompiler() :
       this.compilersByMimeType[type || '__lolnothere'];
 
-    if (!compiler) { 
+    if (!compiler) {
       compiler = this.fallbackCompiler;
 
       let { code, binaryData, mimeType } = compiler.getSync(filePath);
@@ -486,9 +487,10 @@ export default class CompilerHost {
 
     let hashInfo = this.fileChangeCache.getHashForPathSync(filePath);
     let type = mimeTypes.lookup(filePath);
-    
+
     if (hashInfo.isInNodeModules) {
       let code = hashInfo.sourceCode || fs.readFileSync(filePath, 'utf8');
+      code = CompilerHost.fixNodeModulesSourceMapping(code, filePath, this.fileChangeCache.appRoot);
       return { code, mimeType: type };
     }
 
@@ -513,7 +515,7 @@ export default class CompilerHost {
 
   compileUncachedSync(filePath, hashInfo, compiler) {
     let inputMimeType = mimeTypes.lookup(filePath);
-    
+
     if (hashInfo.isFileBinary) {
       return {
         binaryData: hashInfo.binaryData || fs.readFileSync(filePath),
@@ -521,7 +523,7 @@ export default class CompilerHost {
         dependentFiles: []
       };
     }
-  
+
     let ctx = {};
     let code = hashInfo.sourceCode || fs.readFileSync(filePath, 'utf8');
 
@@ -534,15 +536,15 @@ export default class CompilerHost {
 
     let result = compiler.compileSync(code, filePath, ctx);
 
-    let shouldInlineHtmlify = 
+    let shouldInlineHtmlify =
       inputMimeType !== 'text/html' &&
       result.mimeType === 'text/html';
-      
-    let isPassthrough = 
-      result.mimeType === 'text/plain' || 
-      !result.mimeType || 
+
+    let isPassthrough =
+      result.mimeType === 'text/plain' ||
+      !result.mimeType ||
       CompilerHost.shouldPassthrough(hashInfo);
-      
+
     if ((finalForms[result.mimeType] && !shouldInlineHtmlify) || isPassthrough) {
       // Got something we can use in-browser, let's return it
       return _.assign(result, {dependentFiles});
@@ -559,7 +561,7 @@ export default class CompilerHost {
       }
 
       return this.compileUncachedSync(
-        `${filePath}.${mimeTypes.extension(result.mimeType || 'txt')}`, 
+        `${filePath}.${mimeTypes.extension(result.mimeType || 'txt')}`,
         hashInfo, compiler);
     }
   }
@@ -572,17 +574,17 @@ export default class CompilerHost {
       return this.compileSync(f, this.compilersByMimeType);
     });
   }
-  
+
   /*
    * Other stuff
    */
 
 
   /**
-   * Returns the passthrough compiler 
+   * Returns the passthrough compiler
    *
    * @private
-   */   
+   */
   getPassthroughCompiler() {
     return this.compilersByMimeType['text/plain'];
   }
@@ -593,10 +595,34 @@ export default class CompilerHost {
    * some cases, content will still be in cache even if this returns true, and
    * in other cases (isInNodeModules), we'll know explicitly to not even bother
    * looking in the cache.
-   *    
+   *
    * @private
-   */   
+   */
   static shouldPassthrough(hashInfo) {
     return hashInfo.isMinified || hashInfo.isInNodeModules || hashInfo.hasSourceMap || hashInfo.isFileBinary;
+  }
+
+  /**
+   * Look at the code of a node modules and see the sourceMapping path.
+   * If there is any, check the path and try to fix it with and
+   * root relative path.
+   * @private
+   */
+  static fixNodeModulesSourceMapping(sourceCode, sourcePath, appRoot) {
+    let regexSourceMapping = /\/\/#.+sourceMappingURL=(.*)/i;
+    let sourceMappingCheck = sourceCode.match(regexSourceMapping);
+
+    if (sourceMappingCheck && sourceMappingCheck[1] && sourceMappingCheck[1] !== ''){
+        var sourceMapPath = sourceMappingCheck[1];
+        try {
+            fs.statSync(sourceMapPath);
+        } catch (error) {
+            let normRoot = path.normalize(appRoot);
+            let absPathToModule = path.dirname(sourcePath.replace(normRoot, '').substring(1));
+            let newMapPath = path.join(absPathToModule, sourceMapPath);
+            sourceCode = sourceCode.replace(regexSourceMapping, `//# sourceMappingURL=${newMapPath}`);
+        }
+    }
+    return sourceCode;
   }
 }

--- a/src/packager-cli.js
+++ b/src/packager-cli.js
@@ -118,8 +118,13 @@ export async function runAsarArchive(packageDir, asarUnpackDir) {
 export function findExecutableOrGuess(cmdToFind, argsToUse) {
   let { cmd, args } = findActualExecutable(cmdToFind, argsToUse);
   if (cmd === electronPackager) {
+    //With windows you need to add the .cmd to the file name. The raw name will exist but it's a bash script and breaks
+    if (process.platform === 'win32' && cmdToFind.slice(cmdToFind.length - 4) !== '.cmd'){
+      cmdToFind = cmdToFind + '.cmd';
+    }
+
     d(`Can't find ${cmdToFind}, falling back to where it should be as a guess!`);
-    cmd = findActualExecutable(path.resolve(__dirname, '..', '..', '.bin', cmdToFind)).cmd;
+    ({ cmd, args } = findActualExecutable(path.resolve(__dirname, '..', '..', '.bin', cmdToFind), argsToUse));
   }
 
   return { cmd, args };

--- a/test/compiler-host.js
+++ b/test/compiler-host.js
@@ -227,4 +227,46 @@ describe('The compiler host', function() {
       return true;
     });
   });
+
+  it('Should update the sourceMappingURL with the node_modules path', function() {
+    //I need to use path.normalize to support run the test on different OS
+    let nmz = path.normalize;
+    let fix = CompilerHost.fixNodeModulesSourceMapping;
+    let result = '';
+
+    let code = `//# sourceMappingURL=index.ts.map`;
+    let expected = `//# sourceMappingURL=${nmz('node_modules/package/index.ts.map')}`;
+
+    //sourceCode, sourcePath, appRoot
+    result = fix(code, nmz('/some/folder/node_modules/package/code.js'), nmz('/some/folder'));
+    expect(result).to.equal(expected);
+  });
+
+  it('Should leave the sourceMappingURL as it is when is a data URI', function() {
+    //I need to use path.normalize to support run the test on different OS
+    let nmz = path.normalize;
+    let fix = CompilerHost.fixNodeModulesSourceMapping;
+    let result = '';
+
+    let code = `//# sourceMappingURL=data:base64;nomething`;
+    let expected = `//# sourceMappingURL=data:base64;nomething`;
+
+    //sourceCode, sourcePath, appRoot
+    result = fix(code, nmz('/some/folder/node_modules/package/code.js'), nmz('/some/folder'));
+    expect(result).to.equal(expected);
+  });
+
+  it('Should leave the sourceMappingURL as it is when is used in code', function() {
+    //I need to use path.normalize to support run the test on different OS
+    let nmz = path.normalize;
+    let fix = CompilerHost.fixNodeModulesSourceMapping;
+    let result = '';
+
+    let code = `var somevar = "//# sourceMappingURL=" + anotherVar`;
+    let expected = `var somevar = "//# sourceMappingURL=" + anotherVar`;
+
+    //sourceCode, sourcePath, appRoot
+    result = fix(code, nmz('/some/folder/node_modules/package/code.js'), nmz('/some/folder'));
+    expect(result).to.equal(expected);
+  });
 });


### PR DESCRIPTION
Currently if you use npm modules that has sourceMapping, like Angular 2 in Typescript, the mapping won't be loaded because a path difference, this method fix it changing the mapping comment with a root based path.