### PR TITLE
Add passthrough option to selectively disable compilation for certain file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,23 @@ The opening Object is a list of MIME Types, and options passed to the compiler i
 * Less - http://lesscss.org/usage/index.html#command-line-usage-options
 * Jade - http://jade-lang.com/api
 
+## How can I compile only some file types but not others?
+
+With `passthrough` enabled, electron-compile will return your source files completely unchanged!
+
+In this example `.compilerc`, JavaScript files won't be compiled:
+
+```js
+{
+  "application/javascript": {
+    "passthrough": true
+  },
+  "text/less": {
+    "dumpLineNumbers": "comments"
+  }
+}
+```
+
 ## How can I precompile my code for release-time?
 
 electron-compile comes with a wrapper around the [electron-packager](https://github.com/electron-userland/electron-packager) project, `electron-packager-compile` (if you use the `electron-prebuilt-compile` project, this will just be `electron-packager`). Run it the same way you run `electron-packager` and the compilation wire-up will be done in the background.

--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -114,17 +114,24 @@ export function createCompilerHostFromConfiguration(info) {
 
   d(`Creating CompilerHost: ${JSON.stringify(info)}, rootCacheDir = ${rootCacheDir}`);
   let fileChangeCache = new FileChangedCache(info.appRoot);
-  let ret = new CompilerHost(rootCacheDir, compilers, fileChangeCache, false, compilers['text/plain']);
 
   _.each(Object.keys(info.options || {}), (x) => {
     let opts = info.options[x];
     if (!(x in compilers)) {
       throw new Error(`Found compiler settings for missing compiler: ${x}`);
     }
-
+    
+    // NB: Let's hope this isn't a valid compiler option...
+    if (opts.passthrough) {
+      compilers[x] = compilers['text/plain'];
+      delete opts.passthrough;
+    }
+    
     d(`Setting options for ${x}: ${JSON.stringify(opts)}`);
     compilers[x].compilerOptions = opts;
   });
+
+  let ret = new CompilerHost(rootCacheDir, compilers, fileChangeCache, false, compilers['text/plain']);
 
   // NB: It's super important that we guarantee that the configuration is saved
   // out, because we'll need to re-read it in the renderer process

--- a/test/config-parser.js
+++ b/test/config-parser.js
@@ -1,4 +1,5 @@
 import _ from 'lodash';
+import fs from 'fs';
 import path from 'path';
 import mkdirp from 'mkdirp';
 import rimraf from 'rimraf';
@@ -63,6 +64,26 @@ describe('the configuration parser module', function() {
       let lines = compileInfo.code.split('\n');
       expect(lines.length > 5).to.be.ok;
       expect(_.any(lines, (x) => x.match(/sourceMappingURL=/))).not.to.be.ok;
+    });
+    
+    it('creates a no-op compiler when passthrough is set for a mime type', async function() {
+      let fixtureDir = path.join(__dirname, '..', 'test', 'fixtures');
+
+      let sourceFilePath = path.join(fixtureDir, 'valid.js');
+      let sourceFile = fs.readFileSync(sourceFilePath);
+
+      let result = await createCompilerHostFromConfigFile(path.join(fixtureDir, 'compilerc-passthrough'));
+
+      let compileInfo = await result.compile(sourceFilePath);
+      d(JSON.stringify(compileInfo));
+
+      expect(compileInfo.mimeType).to.equal('application/javascript');
+      
+      if (compileInfo.code) {
+        expect(compileInfo.code).to.deep.equal(sourceFile.toString());
+      } else {
+        expect(compileInfo.binaryData).to.equal(sourceFile);
+      }
     });
   });
 

--- a/test/fixtures/compilerc-passthrough
+++ b/test/fixtures/compilerc-passthrough
@@ -1,0 +1,5 @@
+{
+  "application/javascript": {
+    "passthrough": true
+  }
+}


### PR DESCRIPTION
![You. Shall. Pass!](http://i.giphy.com/ABNPHNbhi8I5q.gif)

This PR adds a new `passthrough` option, which will make it possible to use `electron-compile` only for certain file types, instead of for every possible file it supports out of the box. To disable compilation for a file type, you need only set `passthrough: true` for its MIME type in your config:

```js
{
  "application/javascript": {
    "passthrough": true
  },
  "text/less": {
    "dumpLineNumbers": "comments"
  }
}
```

