### PR TITLE
Update to account for code being null on small files

### DIFF
--- a/src/protocol-hook.js
+++ b/src/protocol-hook.js
@@ -141,7 +141,7 @@ export function initializeProtocolHook(compilerHost) {
     try {
       let result = await compilerHost.compile(filePath);
 
-      if (result.mimeType === 'text/html') {
+      if (result.mimeType === 'text/html' && result.code !== null) {
         result.code = rigHtmlDocumentToInitializeElectronCompile(result.code);
       }
 


### PR DESCRIPTION
I had an html file with the following contents

```
<section class="dashboard-container">
	<dashboard></dashboard>
</section>
```

it caused a failure as it was an html file but it was being returned as a buffer.