### PR TITLE
Travis: Install Wine to fix Windows packaging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,15 @@ cache:
   directories:
     - node_modules
 
+addons:
+  apt:
+    packages:
+    - wine
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update      ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install wine; fi
+
 install:
   - npm i -g npm
   - npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ install:
   - npm i -g npm
   - npm install
 
+before_script:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export DISPLAY=:99.0 ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh -e /etc/init.d/xvfb start; sleep 3; fi
+
 script:
   - npm run compile
   - npm run test


### PR DESCRIPTION
It looks like only packager CLI tests [are failing](https://travis-ci.org/electron/electron-compile/jobs/162351011) for Windows packaging, so this is an attempt to fix that.
