### PR TITLE
Correctly return both cmd and args when guessing

### DIFF
--- a/src/packager-cli.js
+++ b/src/packager-cli.js
@@ -117,7 +117,7 @@ export function findExecutableOrGuess(cmdToFind, argsToUse) {
   let { cmd, args } = findActualExecutable(cmdToFind, argsToUse);
   if (cmd === electronPackager) {
     d(`Can't find ${cmdToFind}, falling back to where it should be as a guess!`);
-    cmd = findActualExecutable(path.resolve(__dirname, '..', '..', '.bin', cmdToFind)).cmd;
+    { cmd, args } = findActualExecutable(path.resolve(__dirname, '..', '..', '.bin', `${cmdToFind}${process.platform === 'win32' ? '.cmd' : ''}`), argsToUse);
   }
 
   return { cmd, args };


### PR DESCRIPTION
On Windows when it resorted to guessing where `electron-packager` was it was trying to spawn the wrong thing with no arguments 😆 

Puzzled over this for a while but this tiny fix got everything working 👍 

/cc @paulcbetts 