### PR TITLE
Fix encoding detection on certain files

### DIFF
--- a/src/file-change-cache.js
+++ b/src/file-change-cache.js
@@ -326,8 +326,9 @@ export default class FileChangedCache {
 
     const encodings = ['utf8', 'utf16le'];
 
-    let encoding = encodings.find(
-      (x) => !FileChangedCache.containsControlCharacters(buf.toString(x)));
+    let encoding = encodings.find((x) =>
+      Buffer.compare(new Buffer(buffer.toString(), x), buffer) === 0
+    );
 
     return encoding;
   }

--- a/src/file-change-cache.js
+++ b/src/file-change-cache.js
@@ -326,9 +326,14 @@ export default class FileChangedCache {
 
     const encodings = ['utf8', 'utf16le'];
 
-    let encoding = encodings.find((x) =>
-      Buffer.compare(new Buffer(buffer.toString(), x), buffer) === 0
-    );
+    let encoding;
+    if (buffer.length <= 128) {
+      encoding = encodings.find(x =>
+        Buffer.compare(new Buffer(buffer.toString(), x), buffer) === 0
+      );
+    } else {
+      encoding = encodings.find(x => !FileChangedCache.containsControlCharacters(buf.toString(x)));
+    }
 
     return encoding;
   }

--- a/src/require-hook.js
+++ b/src/require-hook.js
@@ -14,6 +14,9 @@ export default function registerRequireExtension(compilerHost) {
     
     require.extensions[`.${ext}`] = (module, filename) => {
       let {code} = compilerHost.compileSync(filename);
+      if (code === null) {
+        console.error(`null code returned for "${filename}".  Please raise an issue on 'electron-compile' with the contents of this file.`);
+      }
       module._compile(code, filename);
     };
   });


### PR DESCRIPTION
Basically on really small files (maybe like one line) `electron-compile` was detecting them as binary files and therefore not compiling them with `babel`.  This obviously caused issues 👍  

The tests are all still green locally.

I'm not sure how this affects performance.  There weren't any noticeable slowdowns but I think that this might hit performance a tiny bit.

/cc @paulcbetts 