### PR TITLE
Support configuration inheritance

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "@paulcbetts/mime-types": "^2.1.10",
     "btoa": "^1.1.2",
     "debug": "^2.5.1",
+    "lodash.merge": "^4.6.0",
+    "lodash.omit": "^4.5.0",
     "lru-cache": "^4.0.1",
     "mkdirp": "^0.5.1",
     "pify": "^2.3.0",

--- a/test/config-parser.js
+++ b/test/config-parser.js
@@ -2,48 +2,50 @@ import fs from 'fs';
 import path from 'path';
 import mkdirp from 'mkdirp';
 import rimraf from 'rimraf';
+import merge from 'lodash.merge';
 
 import {
-  createCompilers, 
-  createCompilerHostFromConfiguration, 
+  createCompilers,
+  createCompilerHostFromConfiguration,
   createCompilerHostFromConfigFile,
-  createCompilerHostFromBabelRc
+  createCompilerHostFromBabelRc,
+  readCompilerConfiguration
 } from '../src/config-parser';
 
 const d = require('debug')('test:config-parser');
 
 let testCount = 0;
 
-describe('the configuration parser module', function() {
+describe('the configuration parser module', function () {
   this.timeout(10 * 1000);
 
-  describe('the createCompilers method', function() {
-    it('should return compilers', function() {
+  describe('the createCompilers method', function () {
+    it('should return compilers', function () {
       let result = createCompilers();
       expect(Object.keys(result).length > 0).to.be.ok;
     });
 
-    it('should definitely have these compilers', function() {
+    it('should definitely have these compilers', function () {
       let result = createCompilers();
 
       expect(result['application/javascript']).to.be.ok;
       expect(result['text/less']).to.be.ok;
     });
   });
-  
-  describe('the createCompilerHostFromConfiguration method', function() {
-    beforeEach(function() {
+
+  describe('the createCompilerHostFromConfiguration method', function () {
+    beforeEach(function () {
       this.tempCacheDir = path.join(__dirname, `__create_compiler_host_${testCount++}`);
       mkdirp.sync(this.tempCacheDir);
     });
-    
-    afterEach(function() {
+
+    afterEach(function () {
       rimraf.sync(this.tempCacheDir);
     });
-      
-    it('respects suppressing source maps (scenario test)', async function() {
+
+    it('respects suppressing source maps (scenario test)', async function () {
       let fixtureDir = path.join(__dirname, '..', 'test', 'fixtures');
-      
+
       let result = createCompilerHostFromConfiguration({
         appRoot: fixtureDir,
         rootCacheDir: this.tempCacheDir,
@@ -54,18 +56,18 @@ describe('the configuration parser module', function() {
           }
         }
       });
-      
+
       let compileInfo = await result.compile(path.join(fixtureDir, 'valid.js'));
       d(JSON.stringify(compileInfo));
-      
+
       expect(compileInfo.mimeType).to.equal('application/javascript');
-      
+
       let lines = compileInfo.code.split('\n');
       expect(lines.length > 5).to.be.ok;
       expect(lines.find((x) => x.match(/sourceMappingURL=/))).not.to.be.ok;
     });
-    
-    it('creates a no-op compiler when passthrough is set for a mime type', async function() {
+
+    it('creates a no-op compiler when passthrough is set for a mime type', async function () {
       let fixtureDir = path.join(__dirname, '..', 'test', 'fixtures');
 
       let sourceFilePath = path.join(fixtureDir, 'valid.js');
@@ -77,7 +79,7 @@ describe('the configuration parser module', function() {
       d(JSON.stringify(compileInfo));
 
       expect(compileInfo.mimeType).to.equal('application/javascript');
-      
+
       if (compileInfo.code) {
         expect(compileInfo.code).to.deep.equal(sourceFile.toString());
       } else {
@@ -86,123 +88,228 @@ describe('the configuration parser module', function() {
     });
   });
 
-  describe('the createCompilerHostFromBabelRc method', function() {
-    beforeEach(function() {
+  describe('the createCompilerHostFromBabelRc method', function () {
+    beforeEach(function () {
       this.tempCacheDir = path.join(__dirname, `__create_compiler_host_${testCount++}`);
       mkdirp.sync(this.tempCacheDir);
     });
-    
-    afterEach(function() {
+
+    afterEach(function () {
       rimraf.sync(this.tempCacheDir);
       if ('BABEL_ENV' in process.env) {
         delete process.env.ELECTRON_COMPILE_ENV;
       }
     });
-      
-    it('reads from an environment-free file', async function() {
+
+    it('reads from an environment-free file', async function () {
       let fixtureDir = path.join(__dirname, '..', 'test', 'fixtures');
-      
+
       let result = await createCompilerHostFromBabelRc(path.join(fixtureDir, 'babelrc-noenv'));
-      
+
       let compileInfo = await result.compile(path.join(fixtureDir, 'valid.js'));
       d(JSON.stringify(compileInfo));
-      
+
       expect(compileInfo.mimeType).to.equal('application/javascript');
-      
+
       let lines = compileInfo.code.split('\n');
       expect(lines.length > 5).to.be.ok;
       expect(lines.find((x) => x.match(/sourceMappingURL=/))).to.be.ok;
     });
-    
-    it('uses the development env when env is unset', async function() {
+
+    it('uses the development env when env is unset', async function () {
       let fixtureDir = path.join(__dirname, '..', 'test', 'fixtures');
-      
+
       let result = await createCompilerHostFromBabelRc(path.join(fixtureDir, 'babelrc-production'));
-      
+
       let compileInfo = await result.compile(path.join(fixtureDir, 'valid.js'));
       d(JSON.stringify(compileInfo));
-      
+
       expect(compileInfo.mimeType).to.equal('application/javascript');
-      
+
       let lines = compileInfo.code.split('\n');
       expect(lines.length > 5).to.be.ok;
       expect(lines.find((x) => x.match(/sourceMappingURL=/))).to.be.ok;
     });
-    
-    it('uses the production env when env is set', async function() {
+
+    it('uses the production env when env is set', async function () {
       process.env.BABEL_ENV = 'production';
       let fixtureDir = path.join(__dirname, '..', 'test', 'fixtures');
-      
+
       let result = await createCompilerHostFromBabelRc(path.join(fixtureDir, 'babelrc-production'));
-      
+
       let compileInfo = await result.compile(path.join(fixtureDir, 'valid.js'));
       d(JSON.stringify(compileInfo));
-      
+
       expect(compileInfo.mimeType).to.equal('application/javascript');
-      
+
       let lines = compileInfo.code.split('\n');
       expect(lines.length > 5).to.be.ok;
       expect(lines.find((x) => x.match(/sourceMappingURL=/))).not.to.be.ok;
-    });  
+    });
   });
-  
-  describe('the createCompilerHostFromConfigFile method', function() {
-    beforeEach(function() {
+
+  describe('the createCompilerHostFromConfigFile method', function () {
+    beforeEach(function () {
       this.tempCacheDir = path.join(__dirname, `__create_compiler_host_${testCount++}`);
       mkdirp.sync(this.tempCacheDir);
     });
-    
-    afterEach(function() {
+
+    afterEach(function () {
       rimraf.sync(this.tempCacheDir);
       if ('ELECTRON_COMPILE_ENV' in process.env) {
         delete process.env.ELECTRON_COMPILE_ENV;
       }
     });
-      
-    it('reads from an environment-free file', async function() {
+
+    it('reads from an environment-free file', async function () {
       let fixtureDir = path.join(__dirname, '..', 'test', 'fixtures');
-      
+
       let result = await createCompilerHostFromConfigFile(path.join(fixtureDir, 'compilerc-noenv'));
-      
+
       let compileInfo = await result.compile(path.join(fixtureDir, 'valid.js'));
       d(JSON.stringify(compileInfo));
-      
+
       expect(compileInfo.mimeType).to.equal('application/javascript');
-      
+
       let lines = compileInfo.code.split('\n');
       expect(lines.length > 5).to.be.ok;
       expect(lines.find((x) => x.match(/sourceMappingURL=/))).to.be.ok;
     });
-    
-    it('uses the development env when env is unset', async function() {
+
+    it('uses the development env when env is unset', async function () {
       let fixtureDir = path.join(__dirname, '..', 'test', 'fixtures');
-      
+
       let result = await createCompilerHostFromConfigFile(path.join(fixtureDir, 'compilerc-production'));
-      
+
       let compileInfo = await result.compile(path.join(fixtureDir, 'valid.js'));
       d(JSON.stringify(compileInfo));
-      
+
       expect(compileInfo.mimeType).to.equal('application/javascript');
-      
+
       let lines = compileInfo.code.split('\n');
       expect(lines.length > 5).to.be.ok;
       expect(lines.find((x) => x.match(/sourceMappingURL=/))).to.be.ok;
     });
-    
-    it('uses the production env when env is set', async function() {
+
+    it('uses the production env when env is set', async function () {
       process.env.ELECTRON_COMPILE_ENV = 'production';
       let fixtureDir = path.join(__dirname, '..', 'test', 'fixtures');
-      
+
       let result = await createCompilerHostFromConfigFile(path.join(fixtureDir, 'compilerc-production'));
-      
+
       let compileInfo = await result.compile(path.join(fixtureDir, 'valid.js'));
       d(JSON.stringify(compileInfo));
-      
+
       expect(compileInfo.mimeType).to.equal('application/javascript');
-      
+
       let lines = compileInfo.code.split('\n');
       expect(lines.length > 5).to.be.ok;
       expect(lines.find((x) => x.match(/sourceMappingURL=/))).not.to.be.ok;
-    });  
+    });
+  });
+
+  describe('readCompilerConfiguration', () => {
+    const defaultFixture = {
+      "application/javascript": {
+        "presets": ["es2016-node5", "react"],
+        "sourceMaps": "inline"
+      },
+      "text/typescript": {
+        "declaration": false
+      }
+    };
+
+    const envFixture = {
+      "env": {
+        "production": {
+          "application/javascript": {
+            "sourceMaps": false
+          },
+          "text/typescript": {
+            "declaration": true,
+            "jsx": "react"
+          }
+        },
+        "development": {
+          "application/javascript": {
+            "plugins": ["transform-async-to-generator"]
+          },
+          "text/typescript": {
+            "declaration": false
+          }
+        }
+      }
+    };
+
+    it('should read environment-free config', () => {
+      const expected = {
+        "presets": ["es2016-node5", "react"],
+        "sourceMaps": "inline"
+      };
+
+      expect(readCompilerConfiguration(expected)).to.be.equal(expected);
+    });
+
+    it('should read from production env without common', () => {
+      const env = 'production';
+
+      expect(readCompilerConfiguration(envFixture, env))
+        .to.be.deep.equal(envFixture.env[env]);
+    });
+
+    it('should read from development env without common', () => {
+      const env = 'development';
+
+      expect(readCompilerConfiguration(envFixture, env))
+        .to.be.deep.equal(envFixture.env[env]);
+    });
+
+    it('should read from common config inherited production env', () => {
+      const env = 'production';
+      const fixture = merge({}, defaultFixture, envFixture);
+      const expected = {
+        "application/javascript": {
+          "presets": ["es2016-node5", "react"],
+          "sourceMaps": false
+        },
+        "text/typescript": {
+          "declaration": true,
+          "jsx": "react"
+        }
+      };
+
+      expect(readCompilerConfiguration(fixture, env))
+        .to.be.deep.equal(expected);
+    });
+
+    it('should read from common config inherited development env', () => {
+      const env = 'development';
+      const fixture = merge({}, defaultFixture, envFixture);
+      const expected = {
+        "application/javascript": {
+          "presets": ["es2016-node5", "react"],
+          "sourceMaps": "inline",
+          "plugins": ["transform-async-to-generator"]
+        },
+        "text/typescript": {
+          "declaration": false,
+        }
+      };
+
+      expect(readCompilerConfiguration(fixture, env))
+        .to.be.deep.equal(expected);
+    });
+
+    it('should accept environment-free package.json-like config object', () => {
+      const expected = {
+        "presets": ["es2016-node5", "react"],
+        "sourceMaps": "inline"
+      };
+      const fixture = {
+        babel: expected
+      };
+
+      expect(readCompilerConfiguration(fixture)).to.be.equal(expected);
+    });
   });
 });


### PR DESCRIPTION
This PR updates configuration parser supports 'inheritance', allow only specify env-specific config value as needed. 

`.compilerc` now can contain common config values as well as `env` field as well like below example

```js
{
  "application/javascript": {
    "presets": ["es2016-node5", "react"],
    "sourceMaps": "inline"
  },
  "text/typescript": {
    "declaration": false
  },
  "env": {
    "production": {
      "application/javascript": {
        "sourceMaps": false
      },
      "text/typescript": {
        "declaration": true,
        "jsx": "react"
      }
    },
    "development": {
      "application/javascript": {
        "plugins": ["transform-async-to-generator"]
      },
      "text/typescript": {
        "declaration": false
      }
    }
  }
}
```

and per environment configuration, it'll inherit default common values and override to env-specific value if it's specified. 

Theoretically, this'll work not only for `.compilrc` but also for `.babelrc` - however default schema for `babelrc` doesn't allow those type of configuration and it falls back to `dev` env if env is not set, so I don't think this'll be common practice for users use their own babel configuration instead of `.compilerc` though.