### PR TITLE
feat(compileCache): emit external sourcemap if available

### DIFF
--- a/src/compiler-host.js
+++ b/src/compiler-host.js
@@ -66,8 +66,12 @@ export default class CompilerHost {
    *                                         alternate fallback is the compiler for
    *                                         'text/plain', which is guaranteed to be
    *                                         present.
+   *
+   * @param {string} sourceMapPath (optional) The directory to store sourcemap separately
+   *                               if compiler option enabled to emit.
+   *                               Default to cachePath if not specified.
    */
-  constructor(rootCacheDir, compilers, fileChangeCache, readOnlyMode, fallbackCompiler = null) {
+  constructor(rootCacheDir, compilers, fileChangeCache, readOnlyMode, fallbackCompiler = null, sourceMapPath = null) {
     let compilersByMimeType = Object.assign({}, compilers);
     Object.assign(this, {rootCacheDir, compilersByMimeType, fileChangeCache, readOnlyMode, fallbackCompiler});
     this.appRoot = this.fileChangeCache.appRoot;
@@ -78,7 +82,7 @@ export default class CompilerHost {
 
       acc.set(
         compiler,
-        CompileCache.createFromCompiler(rootCacheDir, compiler, fileChangeCache, readOnlyMode));
+        CompileCache.createFromCompiler(rootCacheDir, compiler, fileChangeCache, readOnlyMode, sourceMapPath));
       return acc;
     }, new Map());
   }


### PR DESCRIPTION
This PR enables to write external source map provided by `electron-compiler`, if compiler is configured to emit source map externally.

To support, this PR updates signature of `init()` to accept source map dir as last parameter to allow custom path to store source maps, while default back to cache dir if it's not specified. Also enables one cli argument `--sourcemapdir` as well when someone invokes via cli.

Since this change transparently passthrough sourcemap generated by compiler, user still owns responsibility to control specifics like sourceRoot, maproot, etcs.