### PR TITLE
Enable React HMR using react-hot-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,10 +79,23 @@ import {enableLiveReload} from 'electron-compile';
 enableLiveReload();
 ```
 
-This will do a simple refresh-based reload. If you are using React, you can also enable Hot Module Reloading, with a bit of setup:
+#### React Hot Module Loading
+
+If you are using React, you can also enable Hot Module Reloading for both JavaScript JSX files as well as TypeScript, with a bit of setup:
 
 1. `npm install --save react-hot-loader@next`
 1. Call `enableLiveReload({strategy: 'react-hmr'});` in your main file, after `app.ready` (similar to above)
+1. If you're using TypeScript, you're good out-of-the-box. If you're using JavaScript via Babel, add 'react-hot-loader/babel' to your plugins in `.compilerc`:
+
+```js
+{
+  "application/javascript": {
+    "presets": ["react", "es2017-node7"],
+    "plugins": ['react-hot-loader/babel', 'transform-async-to-generator']
+  }
+}
+```
+
 1. In your `index.html`, replace your initial call to `render`:
 
 Typical code without React HMR:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,40 @@ import {enableLiveReload} from 'electron-compile';
 enableLiveReload();
 ```
 
-Currently LiveReload simply reloads the page, but future versions of electron-compile will support React Hot Module Loading.
+This will do a simple refresh-based reload. If you are using React, you can also enable Hot Module Reloading, with a bit of setup:
+
+1. `npm install --save react-hot-loader@next`
+1. Call `enableLiveReload({strategy: 'react-hmr'});` in your main file, after `app.ready` (similar to above)
+1. In your `index.html`, replace your initial call to `render`:
+
+Typical code without React HMR:
+
+```js
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { MyApp } from './my-app';
+
+ReactDOM.render(<MyApp/>, document.getElementById('app'));
+```
+
+Rewrite this as:
+
+```js
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { AppContainer } from 'react-hot-loader';
+
+const render = () => {
+  // NB: We have to re-require MyApp every time or else this won't work
+  // We also need to wrap our app in the AppContainer class
+  const MyApp = require('./myapp').MyApp;
+  ReactDOM.render(<AppContainer><MyApp/></AppContainer>, document.getElementById('app'));
+}
+
+render();
+if (module.hot) { module.hot.accept(render); }
+```
+
 
 ### Something isn't working / I'm getting weird errors
 

--- a/src/live-reload.js
+++ b/src/live-reload.js
@@ -20,7 +20,7 @@ export function enableLiveReload(options={}) {
   if (process.type !== 'browser' || !global.globalCompilerHost) throw new Error("Call this from the browser process, right after initializing electron-compile");
 
   switch(strategy) {
-  case 'hmr':
+  case 'react-hmr':
     enableReactHMR();
     break;
   case 'naive':
@@ -64,11 +64,11 @@ function triggerHMRInRenderers() {
   BrowserWindow.getAllWindows().forEach((window) => {
     window.webContents.send('__electron-compile__HMR');
   });
-  return Promise.resolve();
 }
 
 function enableReactHMR() {
   global.__electron_compile_hmr_enabled__ = true;
+
   let filesWeCareAbout = global.globalCompilerHost.listenToCompileEvents()
     .filter(x => !FileChangedCache.isInNodeModules(x.filePath))
     .filter(x => x.filePath.endsWith('.js') || x.filePath.endsWith('.jsx'));
@@ -78,5 +78,5 @@ function enableReactHMR() {
     .guaranteedThrottle(1*1000);
 
   return weShouldReload
-    .switchMap(() => Observable.defer(() => Observable.fromPromise(triggerHMRInRenderers()).timeout(5*1000).catch(() => Observable.empty())));
+    .subscribe(() => triggerHMRInRenderers());
 }

--- a/src/live-reload.js
+++ b/src/live-reload.js
@@ -20,6 +20,9 @@ export function enableLiveReload(options={}) {
   if (process.type !== 'browser' || !global.globalCompilerHost) throw new Error("Call this from the browser process, right after initializing electron-compile");
 
   switch(strategy) {
+  case 'hmr':
+    enableReactHMR();
+    break;
   case 'naive':
   default:
     enableLiveReloadNaive();
@@ -55,4 +58,25 @@ function enableLiveReloadNaive() {
   return weShouldReload
     .switchMap(() => Observable.defer(() => Observable.fromPromise(reloadAllWindows()).timeout(5*1000).catch(() => Observable.empty())))
     .subscribe(() => console.log("Reloaded all windows!"));
+}
+
+function triggerHMRInRenderers() {
+  BrowserWindow.getAllWindows().forEach((window) => {
+    window.webContents.send('__electron-compile__HMR');
+  });
+  return Promise.resolve();
+}
+
+function enableReactHMR() {
+  global.__electron_compile_hmr_enabled__ = true;
+  let filesWeCareAbout = global.globalCompilerHost.listenToCompileEvents()
+    .filter(x => !FileChangedCache.isInNodeModules(x.filePath))
+    .filter(x => x.filePath.endsWith('.js') || x.filePath.endsWith('.jsx'));
+
+  let weShouldReload = filesWeCareAbout
+    .mergeMap(x => watchPath(x.filePath).map(() => x))
+    .guaranteedThrottle(1*1000);
+
+  return weShouldReload
+    .switchMap(() => Observable.defer(() => Observable.fromPromise(triggerHMRInRenderers()).timeout(5*1000).catch(() => Observable.empty())));
 }

--- a/src/require-hook.js
+++ b/src/require-hook.js
@@ -1,4 +1,18 @@
 import mimeTypes from '@paulcbetts/mime-types';
+import electron from 'electron';
+
+const HMR = electron.remote && electron.remote.getGlobal('__electron_compile_hmr_enabled__');
+const HMRSupported = ['text/jsx', 'application/javascript'];
+
+if (process.type === 'renderer') {
+  window.__hot = [];
+
+  electron.ipcRenderer.on('__electron-compile__HMR', () => {
+    // Reset the module cache
+    require('module')._cache = {};
+    window.__hot.forEach(fn => fn());
+  });
+}
 
 /**
  * Initializes the node.js hook that allows us to intercept files loaded by
@@ -11,9 +25,13 @@ import mimeTypes from '@paulcbetts/mime-types';
 export default function registerRequireExtension(compilerHost) {
   Object.keys(compilerHost.compilersByMimeType).forEach((mimeType) => {
     let ext = mimeTypes.extension(mimeType);
+    const injectModuleHot = HMR && (HMRSupported.indexOf(mimeType) !== -1);
 
     require.extensions[`.${ext}`] = (module, filename) => {
       let {code} = compilerHost.compileSync(filename);
+      if (injectModuleHot) {
+        code = 'module.hot={accept:(cb)=>window.__hot.push(cb)};' + code;
+      }
       if (code === null) {
         console.error(`null code returned for "${filename}".  Please raise an issue on 'electron-compile' with the contents of this file.`);
       }

--- a/src/require-hook.js
+++ b/src/require-hook.js
@@ -3,6 +3,8 @@ import electron from 'electron';
 
 let HMR = false;
 
+const d = require('debug')('electron-compile:require-hook');
+
 if (process.type === 'renderer') {
   window.__hot = [];
   HMR = electron.remote.getGlobal('__electron_compile_hmr_enabled__');
@@ -13,8 +15,11 @@ if (process.type === 'renderer') {
 
       // Reset the module cache
       let cache = require('module')._cache;
-      let toEject = Object.keys(cache).filter(x => x && !x.match(/\\\/(node_modules|.*asar)\\\//i));
-      toEject.forEach(x => delete cache[x]);
+      let toEject = Object.keys(cache).filter(x => x && !x.match(/[\\\/](node_modules|.*\.asar)[\\\/]/i));
+      toEject.forEach(x => {
+        d(`Removing node module entry for ${x}`);
+        delete cache[x];
+      });
 
       window.__hot.forEach(fn => fn());
     });

--- a/src/require-hook.js
+++ b/src/require-hook.js
@@ -1,17 +1,24 @@
 import mimeTypes from '@paulcbetts/mime-types';
 import electron from 'electron';
 
-const HMR = electron.remote && electron.remote.getGlobal('__electron_compile_hmr_enabled__');
+let HMR = false;
 const HMRSupported = ['text/jsx', 'application/javascript'];
 
 if (process.type === 'renderer') {
   window.__hot = [];
+  HMR = electron.remote.getGlobal('__electron_compile_hmr_enabled__');
 
   electron.ipcRenderer.on('__electron-compile__HMR', () => {
     // Reset the module cache
     require('module')._cache = {};
     window.__hot.forEach(fn => fn());
   });
+
+  try {
+    require('react-hot-loader/patch');
+  } catch (e) {
+    console.error(`Couldn't require react-hot-loader/patch, you need to add react-hot-loader@3 as a dependency! ${e.message}`);
+  }
 }
 
 /**

--- a/src/require-hook.js
+++ b/src/require-hook.js
@@ -8,16 +8,18 @@ if (process.type === 'renderer') {
   window.__hot = [];
   HMR = electron.remote.getGlobal('__electron_compile_hmr_enabled__');
 
-  electron.ipcRenderer.on('__electron-compile__HMR', () => {
-    // Reset the module cache
-    require('module')._cache = {};
-    window.__hot.forEach(fn => fn());
-  });
+  if (HMR) {
+    electron.ipcRenderer.on('__electron-compile__HMR', () => {
+      // Reset the module cache
+      require('module')._cache = {};
+      window.__hot.forEach(fn => fn());
+    });
 
-  try {
-    require('react-hot-loader/patch');
-  } catch (e) {
-    console.error(`Couldn't require react-hot-loader/patch, you need to add react-hot-loader@3 as a dependency! ${e.message}`);
+    try {
+      require('react-hot-loader/patch');
+    } catch (e) {
+      console.error(`Couldn't require react-hot-loader/patch, you need to add react-hot-loader@3 as a dependency! ${e.message}`);
+    }
   }
 }
 
@@ -36,12 +38,15 @@ export default function registerRequireExtension(compilerHost) {
 
     require.extensions[`.${ext}`] = (module, filename) => {
       let {code} = compilerHost.compileSync(filename);
+
       if (injectModuleHot) {
         code = 'module.hot={accept:(cb)=>window.__hot.push(cb)};' + code;
       }
+
       if (code === null) {
         console.error(`null code returned for "${filename}".  Please raise an issue on 'electron-compile' with the contents of this file.`);
       }
+
       module._compile(code, filename);
     };
   });

--- a/src/require-hook.js
+++ b/src/require-hook.js
@@ -2,7 +2,6 @@ import mimeTypes from '@paulcbetts/mime-types';
 import electron from 'electron';
 
 let HMR = false;
-const HMRSupported = ['text/jsx', 'application/javascript'];
 
 if (process.type === 'renderer') {
   window.__hot = [];
@@ -10,16 +9,15 @@ if (process.type === 'renderer') {
 
   if (HMR) {
     electron.ipcRenderer.on('__electron-compile__HMR', () => {
+      console.log("Got HMR signal!");
+
       // Reset the module cache
-      require('module')._cache = {};
+      let cache = require('module')._cache;
+      let toEject = Object.keys(cache).filter(x => x && !x.match(/\\\/(node_modules|.*asar)\\\//i));
+      toEject.forEach(x => delete cache[x]);
+
       window.__hot.forEach(fn => fn());
     });
-
-    try {
-      require('react-hot-loader/patch');
-    } catch (e) {
-      console.error(`Couldn't require react-hot-loader/patch, you need to add react-hot-loader@3 as a dependency! ${e.message}`);
-    }
   }
 }
 
@@ -32,16 +30,23 @@ if (process.type === 'renderer') {
  * @param  {CompilerHost} compilerHost  The compiler host to use for compilation.
  */
 export default function registerRequireExtension(compilerHost) {
+  if (HMR) {
+    try {
+      require('module').prototype.hot = {
+        accept: (cb) => window.__hot.push(cb)
+      };
+
+      require.main.require('react-hot-loader/patch');
+    } catch (e) {
+      console.error(`Couldn't require react-hot-loader/patch, you need to add react-hot-loader@3 as a dependency! ${e.message}`);
+    }
+  }
+
   Object.keys(compilerHost.compilersByMimeType).forEach((mimeType) => {
     let ext = mimeTypes.extension(mimeType);
-    const injectModuleHot = HMR && (HMRSupported.indexOf(mimeType) !== -1);
 
     require.extensions[`.${ext}`] = (module, filename) => {
       let {code} = compilerHost.compileSync(filename);
-
-      if (injectModuleHot) {
-        code = 'module.hot={accept:(cb)=>window.__hot.push(cb)};' + code;
-      }
 
       if (code === null) {
         console.error(`null code returned for "${filename}".  Please raise an issue on 'electron-compile' with the contents of this file.`);


### PR DESCRIPTION
This enables a webpack-ish Hot Module Reloading API for React components (currently only tested / supporting `.js` and `.jsx` files).  An example of how to use this API is below.

```js
import React from 'react';
import ReactDOM from 'react-dom';
import App from './app';

import { AppContainer } from 'react-hot-loader';

ReactDOM.render(
  <AppContainer>
    <App />
  </AppContainer>
  , document.getElementById('App'));

if (module.hot) {
  module.hot.accept(() => {
    const NewApp = require('./app').default;
    ReactDOM.render(
      <AppContainer>
        <NewApp />
      </AppContainer>
      , document.getElementById('App'));
  });
}
```

You basically just need to the same set up as normal for `react-hot-loader`.

* `import 'react-hot-loader/patch';` before any of your code runs, this should be an your HTML script tag probably
* `"react-hot-loader/babel"` as a babel plugin in your `.compilerc`
* `react-hot-loader` as a dependency (you need the beta, something like `3.0.0-beta.6`)

Admittedly this is a relatively hacked in solution but it requires minimal changes and uses the already well established and tested `react-hot-loader` module 👍 

Also it totally works 😄 

[Electron React HMR Demo Video.zip](https://github.com/electron/electron-compile/files/784803/Electron.React.HMR.Demo.Video.zip)
