### PR TITLE
fix(configParser): correctly honor sourcemapPath

### DIFF
--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -112,7 +112,7 @@ export function init(appRoot, mainModule, productionMode = null, cacheDir = null
 export function createCompilerHostFromConfiguration(info) {
   let compilers = createCompilers();
   let rootCacheDir = info.rootCacheDir || calculateDefaultCompileCacheDirectory();
-  const sourceMapPath = info.rootCacheDir || info.sourceMapPath;
+  const sourceMapPath = info.sourceMapPath || info.rootCacheDir;
 
   if (info.sourceMapPath) {
     createSourceMapDirectory(sourceMapPath);


### PR DESCRIPTION
This PR fixes incorrect behavior of reading sourceMapPath, falls back to rootcacheDir always instead of separate sourcemapPath.