### PR TITLE
feat(saveSourceMap): honor source folder hierarchy

### DIFF
--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -144,7 +144,7 @@ export function createCompilerHostFromConfiguration(info) {
     compilers[x].compilerOptions = opts;
   });
 
-  let ret = new CompilerHost(rootCacheDir, compilers, fileChangeCache, false, compilers['text/plain']);
+  let ret = new CompilerHost(rootCacheDir, compilers, fileChangeCache, false, compilers['text/plain'], sourceMapPath);
 
   // NB: It's super important that we guarantee that the configuration is saved
   // out, because we'll need to re-read it in the renderer process


### PR DESCRIPTION
This PR is following changes to #185 and improves behavior of saving sourcemap, by honoring `appRoot` and create relative path under sourcemapPath when generates sourcemap.

This behavior supports 2 usecases, 
- if there are same file name under different paths (`src/main/main.ts`, `src/renderer/main.ts`) flattened sourcemap emission will overwrite one eventually
- sourcemap lookup based on sourceroot / maproot is based on relative path hierarchy of original source, so if someone try to utilize it they may need to reconstruct structures from flattened one.

Now with this PR by default it honors appRoot and construct same hierarchies, and if someone need to flatten sourcemap can do after compilation is done. (manually).