### PR TITLE
Added per mimetype reload strategies and stylesheet live reloading.

### DIFF
--- a/src/live-reload.js
+++ b/src/live-reload.js
@@ -56,7 +56,8 @@ const defaultOptions = {
     'application/javascript': 'react-hmr',
     'text/stylus': 'hot-stylesheets',
     'text/sass': 'hot-stylesheets',
-    'text/scss': 'hot-stylesheets'
+    'text/scss': 'hot-stylesheets',
+    'text/css' : 'hot-stylesheets'
   }
 }
 

--- a/src/live-reload.js
+++ b/src/live-reload.js
@@ -65,9 +65,6 @@ function setupWatchHMR(filePath) {
 }
 
 function setWatchHotAssets(filePath) {
-  // Deep dependencies of stylesheets don't seem to hit the CompilerHost 
-  // so we generate our own dependency trees.
-
   watchPath(filePath).subscribe(() => triggerAssetReloadInRenderers(filePath))
 }
 

--- a/src/live-reload.js
+++ b/src/live-reload.js
@@ -54,9 +54,9 @@ const defaultOptions = {
     'text/tsx': 'react-hmr',
     'text/jsx': 'react-hmr',
     'application/javascript': 'react-hmr',
-    'text/stylus': 'hot-assets',
-    'text/sass': 'hot-assets',
-    'text/scss': 'hot-assets'
+    'text/stylus': 'hot-stylesheets',
+    'text/sass': 'hot-stylesheets',
+    'text/scss': 'hot-stylesheets'
   }
 }
 
@@ -83,7 +83,7 @@ export function enableLiveReload(options=defaultOptions) {
     case 'react-hmr':
       global.__electron_compile_hmr_enabled__ = true;
       break;
-    case 'hot-assets':
+    case 'hot-stylesheets':
       global.__electron_compile_stylesheet_reload_enabled__ = true;
       break;
     }
@@ -97,7 +97,7 @@ export function enableLiveReload(options=defaultOptions) {
       case 'react-hmr':
         setupWatchHMR(x.filePath)
         break;
-      case 'hot-assets':
+      case 'hot-stylesheets':
         setWatchHotAssets(x.filePath)
         break;
       case 'naive':

--- a/src/live-reload.js
+++ b/src/live-reload.js
@@ -33,8 +33,6 @@ function reloadAllWindows() {
 }
 
 function triggerHMRInRenderers() {
-  console.log('wat')
-
   BrowserWindow.getAllWindows().forEach((window) => {
     window.webContents.send('__electron-compile__HMR');
   });
@@ -81,8 +79,6 @@ export function enableLiveReload(options=defaultOptions) {
   let { strategy } = options;
 
   if (process.type !== 'browser' || !global.globalCompilerHost) throw new Error("Call this from the browser process, right after initializing electron-compile");
-
-  console.log()
 
   // Enable the methods described in the reload strategy
   for (let mime of Object.keys(strategy)) { 

--- a/src/require-hook.js
+++ b/src/require-hook.js
@@ -1,6 +1,7 @@
 import mimeTypes from '@paulcbetts/mime-types';
 
 let HMR = false;
+let stylesheetReload = false;
 
 const d = require('debug')('electron-compile:require-hook');
 let electron = null;
@@ -9,6 +10,7 @@ if (process.type === 'renderer') {
   window.__hot = [];
   electron = require('electron');
   HMR = electron.remote.getGlobal('__electron_compile_hmr_enabled__');
+  stylesheetReload = electron.remote.getGlobal('__electron_compile_stylesheet_reload_enabled__');
 
   if (HMR) {
     electron.ipcRenderer.on('__electron-compile__HMR', () => {
@@ -23,6 +25,30 @@ if (process.type === 'renderer') {
       });
 
       window.__hot.forEach(fn => fn());
+    });
+  }
+
+  if (stylesheetReload) {
+    electron.ipcRenderer.on('__electron-compile__stylesheet_reload', (e, path) => {
+      /*if (path.match(/.(jpg|jpeg|png|gif)$/i)) {
+        let images = document.getElementsByTagName('img');
+
+        for (let img of images) {
+          let uri = img.src
+          if (uri.includes(path)) {
+            img.src = img.src; // trigger an update
+          }
+        }
+      } else {*/
+        let links = document.getElementsByTagName('link');
+
+        for (let link of links) {
+          let uri = link.href
+          if (uri.includes(path)) {
+            link.href = link.href; // trigger a reload for this stylesheet
+          }
+        }
+      //}
     });
   }
 }


### PR DESCRIPTION
Per mimeType reload strategies have been added. Now you should be able to call `enableLiveReload()` without any arguments and get something that works very out of the box. Alternatively you can pass in an options object that contains your reload strategy.

```
  'strategy': {
    'text/html': 'naive',
    'text/tsx': 'react-hmr',
    'text/jsx': 'react-hmr',
    'application/javascript': 'react-hmr',
    'text/stylus': 'hot-stylesheets',
    'text/sass': 'hot-stylesheets',
    'text/scss': 'hot-stylesheets',
    'text/css' : 'hot-stylesheets'
  }
```

Additionally, stylesheets can now be hot reloaded. Their link.href will be reset upon the file changing.

This doesn't work for dependencies for stylesheets. I've opened an issue regarding `electron-compile-compiled-file` not being sent for dependencies for stylesheets.