### PR TITLE
Use chokidar instead of fs for watching files.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@paulcbetts/mime-types": "^2.1.10",
     "btoa": "^1.1.2",
+    "chokidar": "^1.6.1",
     "debug": "^2.5.1",
     "lru-cache": "^4.0.1",
     "mkdirp": "^0.5.1",

--- a/src/pathwatcher-rx.js
+++ b/src/pathwatcher-rx.js
@@ -1,7 +1,7 @@
-import fs from 'fs';
 import {Observable} from 'rxjs/Observable';
 import {Subscription} from 'rxjs/Subscription';
 import LRU from 'lru-cache';
+import chokidar from 'chokidar';
 
 import 'rxjs/add/operator/publish';
 
@@ -9,9 +9,12 @@ export function watchPathDirect(directory) {
   return Observable.create((subj) => {
     let dead = false;
 
-    const watcher = fs.watch(directory, {}, (eventType, fileName) => {
+    const watcher = chokidar.watch(directory)
+
+    watcher.on('change', (fileName) => {
       if (dead) return;
-      subj.next({eventType, fileName});
+  
+      subj.next({fileName});
     });
 
     watcher.on('error', (e) => {


### PR DESCRIPTION
This fixes #189 by changing the watchPath function to use chokidar.

No more multiple watch events being called, we can remove the throttling done by the hot reloading code.