### PR TITLE
Make file watching more robust

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@paulcbetts/mime-types": "^2.1.10",
     "btoa": "^1.1.2",
     "debug": "^2.5.1",
+    "gaze": "^1.1.2",
     "lru-cache": "^4.0.1",
     "mkdirp": "^0.5.1",
     "pify": "^2.3.0",

--- a/src/custom-operators.js
+++ b/src/custom-operators.js
@@ -24,12 +24,6 @@ function retryWithDelayOrError(errors, maxRetries) {
 }
 
 const newCoolOperators = {
-  guaranteedThrottle: function(time, scheduler = async) {
-    return this
-      .map((x) => Observable.timer(time, scheduler).map(() => x))
-      .switch();
-  },
-
   retryAtIntervals: function(maxRetries = 3) {
     return this.retryWhen((errors) => retryWithDelayOrError(errors, maxRetries));
   },

--- a/src/live-reload.js
+++ b/src/live-reload.js
@@ -52,8 +52,7 @@ function enableLiveReloadNaive() {
     .filter(x => !FileChangedCache.isInNodeModules(x.filePath));
 
   let weShouldReload = filesWeCareAbout
-    .mergeMap(x => watchPath(x.filePath).map(() => x))
-    .guaranteedThrottle(1*1000);
+    .mergeMap(x => watchPath(x.filePath).map(() => x));
 
   return weShouldReload
     .switchMap(() => Observable.defer(() => Observable.fromPromise(reloadAllWindows()).timeout(5*1000).catch(() => Observable.empty())))
@@ -75,8 +74,7 @@ function enableReactHMR() {
     .filter(x => !FileChangedCache.isInNodeModules(x.filePath));
 
   let weShouldReload = filesWeCareAbout
-    .mergeMap(x => watchPath(x.filePath).map(() => x))
-    .guaranteedThrottle(1*1000);
+    .mergeMap(x => watchPath(x.filePath).map(() => x));
 
   return weShouldReload
     .switchMap(() => Observable.defer(() => Observable.fromPromise(triggerHMRInRenderers()).catch(() => Observable.empty())))


### PR DESCRIPTION
Fixes #189, fixes #193

See #193 for more information

Use `gaze` instead of `fs.watch()` for file watching.

Fix an issue where `fs.watch()` does not detect file changes when using
certain text editor features such as `backupcopy` in Vim.

Fix an issue where multiple change events are received for the same
change.

Improve HMR speed by removing manual throttling on file changes in favor
of the more robust debouncing performed by `gaze`.

@paulcbetts mentioned experiencing issues on Windows in #190. It would be great to hear if this resolves those issues.