### PR TITLE
Define list of MIME types to passthrough (for #167)

### DIFF
--- a/src/compiler-host.js
+++ b/src/compiler-host.js
@@ -26,6 +26,8 @@ const finalForms = {
   'application/json': true
 };
 
+const mimeTypesToPassthrough = ['text/plain', 'application/xml'];
+
 /**
  * This class is the top-level class that encapsulates all of the logic of
  * compiling and caching application code. If you're looking for a "Main class",
@@ -342,12 +344,8 @@ export default class CompilerHost {
       inputMimeType !== 'text/html' &&
       result.mimeType === 'text/html';
 
-    let isPassthrough =
-      result.mimeType === 'text/plain' ||
-      !result.mimeType ||
-      CompilerHost.shouldPassthrough(hashInfo);
 
-    if ((finalForms[result.mimeType] && !shouldInlineHtmlify) || isPassthrough) {
+    if ((finalForms[result.mimeType] && !shouldInlineHtmlify) || _isPassthrough(result, hashInfo)) {
       // Got something we can use in-browser, let's return it
       return Object.assign(result, {dependentFiles});
     } else {
@@ -575,12 +573,7 @@ export default class CompilerHost {
       inputMimeType !== 'text/html' &&
       result.mimeType === 'text/html';
 
-    let isPassthrough =
-      result.mimeType === 'text/plain' ||
-      !result.mimeType ||
-      CompilerHost.shouldPassthrough(hashInfo);
-
-    if ((finalForms[result.mimeType] && !shouldInlineHtmlify) || isPassthrough) {
+    if ((finalForms[result.mimeType] && !shouldInlineHtmlify) || _isPassthrough(result, hashInfo)) {
       // Got something we can use in-browser, let's return it
       return Object.assign(result, {dependentFiles});
     } else {
@@ -690,4 +683,17 @@ export default class CompilerHost {
 
     return sourceCode;
   }
+}
+
+// Private helper functions
+// (to help DRY up CompilerHost methods with shared code such as compileUncached & compileUncachedSync)
+
+function _isPassthrough(result, hashInfo) {
+  return _shouldIgnoreMimeType(result.mimeType) ||
+    CompilerHost.shouldPassthrough(hashInfo);
+}
+
+function _shouldIgnoreMimeType(mimeType) {
+  return mimeTypesToPassthrough.indexOf(mimeType) !== -1 ||
+    !mimeType;
 }


### PR DESCRIPTION
I'd really like to be able to avoid warnings or errors when my application builds. In my case there are some XML files that should not be processed by `electron-compile` at all, but I can't seem to specify this anywhere. Since the meaning of `application/xml` content is application specific I suspect there is little, if any, translation that should be done (perhaps the condensing of white space?), might it make sense to have these be ignored by default? 

I'm not familiar with your codebase, but it looks like something like this should work for this purpose, right?