### PR TITLE
electron-compile now implicitly uses babel-preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,7 +11,7 @@
     },
     "development": {
       "presets": ["es2016-node5", "react"],
-      "plugins": ["transform-async-to-generator", "array-includes", "istanbul"],
+      "plugins": ["transform-async-to-generator", "array-includes"],
       "sourceMaps": "inline"
     }
   }

--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "presets": ["es2016-node5", "react"],
       "plugins": ["transform-async-to-generator", "array-includes", "istanbul"],
       "sourceMaps": "inline"
-    }, 
+    },
     "production": {
       "presets": ["es2016-node5", "react"],
       "plugins": ["transform-async-to-generator", "array-includes"],

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Electron supporting package to compile JS and CSS in Electron applications",
   "scripts": {
     "doc": "esdoc -c ./esdoc.json",
-    "compile": "git clean -xdf lib && babel -d lib/ src",
+    "compile": "cross-env NODE_ENV='production' git clean -xdf lib && babel -d lib/ src",
     "prepublish": "npm run compile",
     "start": "npm run compile && electron ./test-dist/electron-smoke-test.js",
     "test": "mocha --compilers js:babel-register test/*.js",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "chai-as-promised": "^5.3.0",
     "cheerio": "^0.20.0",
     "cross-env": "^3.2.4",
-    "electron-compilers": "^5.5.1",
+    "electron-compilers": "^5.7.0-beta.1",
     "electron-packager": "^7.5.1",
     "electron-prebuilt": "^1.3.3",
     "esdoc": "^0.4.8",

--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -362,7 +362,7 @@ export function getDefaultConfiguration() {
       "presets": [
         ["env", {
           "targets": {
-            "electron": process.versions.electron
+            "electron": parseFloat(process.versions.electron.replace(/^([^\.]\.[^\.])\..*$/, '$1'))
           }
         }],
         "react"

--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -351,6 +351,30 @@ function createSourceMapDirectory(sourceMapPath) {
   d(`Using separate sourcemap path at ${sourceMapPath}`);
 }
 
+function versionToFloat(ver) {
+  return parseFloat(ver.replace(/^([^\.]\.[^\.])\..*$/, '$1'));
+}
+
+function getElectronVersion() {
+  if (process.versions.electron) {
+    return versionToFloat(process.versions.electron);
+  }
+
+  let pkgJson = ['electron-prebuilt-compile', 'electron'].find(mod => {
+    try {
+      return process.mainModule.require(`${mod}/package.json`);
+    } catch (e) {
+      return null;
+    }
+  });
+
+  if (!pkgJson) {
+    throw new Error("Can't automatically discover the version of Electron, you probably need a .compilerc file");
+  }
+
+  return versionToFloat(pkgJson.version);
+}
+
 /**
  * Returns the default .configrc if no configuration information can be found.
  *
@@ -362,7 +386,7 @@ export function getDefaultConfiguration() {
       "presets": [
         ["env", {
           "targets": {
-            "electron": parseFloat(process.versions.electron.replace(/^([^\.]\.[^\.])\..*$/, '$1'))
+            "electron": getElectronVersion()
           }
         }],
         "react"

--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -359,7 +359,14 @@ function createSourceMapDirectory(sourceMapPath) {
 export function getDefaultConfiguration() {
   return {
     'application/javascript': {
-      "presets": ["es2016-node5", "react"],
+      "presets": [
+        ["env", {
+          "targets": {
+            "electron": process.versions.electron
+          }
+        }],
+        "react"
+      ],
       "sourceMaps": "inline"
     }
   };

--- a/src/index.js
+++ b/src/index.js
@@ -3,10 +3,23 @@ import * as configParser from './config-parser';
 import CompilerHost from './compiler-host';
 import FileChangedCache from './file-change-cache';
 import CompileCache from './compile-cache';
-import {enableLiveReload} from './live-reload';
-import {watchPath} from './pathwatcher-rx';
+//import {enableLiveReload} from './live-reload';
+//import {watchPath} from './pathwatcher-rx';
 
-module.exports = Object.assign({},
+let enableLiveReload = null;
+let watchPath = null;
+
+module.exports = Object.assign({
+  // NB: delay-load live-reload so we don't load RxJS in production
+  enableLiveReload: function() {
+    enableLiveReload = enableLiveReload || require('./live-reload').enableLiveReload;
+    return enableLiveReload(arguments);
+  },
+  watchPath: function() {
+    watchPath = watchPath || require('./pathwatcher-rx').watchPath;
+    return watchPath(arguments);
+  },
+},
   configParser,
-  { enableLiveReload, watchPath, CompilerHost, FileChangedCache, CompileCache }
+  { CompilerHost, FileChangedCache, CompileCache }
 );

--- a/test/compile-cache.js
+++ b/test/compile-cache.js
@@ -136,7 +136,7 @@ describe('The compile cache', function() {
     expect(callCount).to.equal(1);
   });
 
-  it.only('Shouldnt cache compile failures', async function() {
+  it('Shouldnt cache compile failures', async function() {
     let inputFile = path.resolve(__dirname, '..', 'lib', 'compile-cache.js');
     let callCount = 0;
     let weBlewUpCount = 0;

--- a/test/compile-cache.js
+++ b/test/compile-cache.js
@@ -16,151 +16,152 @@ describe('The compile cache', function() {
   beforeEach(function() {
     this.appRootDir = path.join(__dirname, '..');
     this.fileChangeCache = new FileChangeCache(this.appRootDir);
-    
+
     this.tempCacheDir = path.join(__dirname, `__compile_cache_${testCount++}`);
     mkdirp.sync(this.tempCacheDir);
     this.fixture = new CompileCache(this.tempCacheDir, this.fileChangeCache);
   });
-  
+
   afterEach(function() {
     rimraf.sync(this.tempCacheDir);
   });
-  
+
   it('Should only call compile once for the same file', async function() {
     let inputFile = path.resolve(__dirname, '..', 'src', 'compile-cache.js');
     let callCount = 0;
-    
+
     let fetcher = async function(filePath, hashInfo) {
       callCount++;
-      
+
       let code = hashInfo.sourceCode || await pfs.readFile(filePath, 'utf8');
       let mimeType = 'application/javascript';
-      let dependentFiles = []
+      let dependentFiles = [];
       return { code, mimeType, dependentFiles };
     };
-    
+
     let result = await this.fixture.getOrFetch(inputFile, fetcher);
-    
+
     expect(result.mimeType).to.equal('application/javascript');
     expect(result.code.length > 10).to.be.ok;
     expect(callCount).to.equal(1);
-    
+
     result = await this.fixture.getOrFetch(inputFile, fetcher);
-      
+
     expect(result.mimeType).to.equal('application/javascript');
     expect(result.code.length > 10).to.be.ok;
     expect(callCount).to.equal(1);
-    
+
     this.fixture = new CompileCache(this.tempCacheDir, this.fileChangeCache);
-        
+
     result = await this.fixture.getOrFetch(inputFile, fetcher);
-      
-    expect(result.mimeType).to.equal('application/javascript');
-    expect(result.code.length > 10).to.be.ok;
-    expect(callCount).to.equal(1);
-  });
-    
-  it('Should roundtrip binary files', async function() {
-    let inputFile = path.resolve(__dirname, '..', 'test', 'fixtures', 'binaryfile.zip');
-    let hashInfo = await this.fileChangeCache.getHashForPath(inputFile);
-    
-    await this.fixture.save(hashInfo, hashInfo.binaryData, 'application/zip');
-    
-    let fetcher = async function() {
-      throw new Error("No");
-    };
-    
-    let result = await this.fixture.getOrFetch(inputFile, fetcher);
-    expect(result.mimeType).to.equal('application/zip');
-    expect(result.binaryData.length).to.equal(hashInfo.binaryData.length);
-  
-    this.fixture = new CompileCache(this.tempCacheDir, this.fileChangeCache);
-        
-    result = await this.fixture.getOrFetch(inputFile, fetcher);
-    expect(result.mimeType).to.equal('application/zip');
-    expect(result.binaryData.length).to.equal(hashInfo.binaryData.length);  
-  });
-    
-  it('Should roundtrip binary files synchronously', function() {
-    let inputFile = path.resolve(__dirname, '..', 'test', 'fixtures', 'binaryfile.zip');
-    let hashInfo = this.fileChangeCache.getHashForPathSync(inputFile);
-    
-    this.fixture.saveSync(hashInfo, hashInfo.binaryData, 'application/zip');
-    
-    let fetcher = function() {
-      throw new Error("No");
-    };
-    
-    let result = this.fixture.getOrFetchSync(inputFile, fetcher);
-    expect(result.mimeType).to.equal('application/zip');
-    expect(result.binaryData.length).to.equal(hashInfo.binaryData.length);
-  
-    this.fixture = new CompileCache(this.tempCacheDir, this.fileChangeCache);
-        
-    result = this.fixture.getOrFetchSync(inputFile, fetcher);
-    expect(result.mimeType).to.equal('application/zip');
-    expect(result.binaryData.length).to.equal(hashInfo.binaryData.length);  
-  });
-  
-  it('Should only call compile once for the same file synchronously', function() {
-    let inputFile = path.resolve(__dirname, '..', 'src', 'compile-cache.js');
-    let callCount = 0;
-    
-    let fetcher = function(filePath, hashInfo) {
-      callCount++;
-      
-      let code = hashInfo.sourceCode || fs.readFileSync(filePath, 'utf8');
-      let mimeType = 'application/javascript';
-      
-      return { code, mimeType };
-    };
-    
-    let result = this.fixture.getOrFetchSync(inputFile, fetcher);
-    
-    expect(result.mimeType).to.equal('application/javascript');
-    expect(result.code.length > 10).to.be.ok;
-    expect(callCount).to.equal(1);
-    
-    result = this.fixture.getOrFetchSync(inputFile, fetcher);
-      
-    expect(result.mimeType).to.equal('application/javascript');
-    expect(result.code.length > 10).to.be.ok;
-    expect(callCount).to.equal(1);
-    
-    this.fixture = new CompileCache(this.tempCacheDir, this.fileChangeCache);
-        
-    result = this.fixture.getOrFetchSync(inputFile, fetcher);
-      
+
     expect(result.mimeType).to.equal('application/javascript');
     expect(result.code.length > 10).to.be.ok;
     expect(callCount).to.equal(1);
   });
 
-  it('Shouldnt cache compile failures', async function() {
+  it('Should roundtrip binary files', async function() {
+    let inputFile = path.resolve(__dirname, '..', 'test', 'fixtures', 'binaryfile.zip');
+    let hashInfo = await this.fileChangeCache.getHashForPath(inputFile);
+
+    await this.fixture.save(hashInfo, hashInfo.binaryData, 'application/zip');
+
+    let fetcher = async function() {
+      throw new Error("No");
+    };
+
+    let result = await this.fixture.getOrFetch(inputFile, fetcher);
+    expect(result.mimeType).to.equal('application/zip');
+    expect(result.binaryData.length).to.equal(hashInfo.binaryData.length);
+
+    this.fixture = new CompileCache(this.tempCacheDir, this.fileChangeCache);
+
+    result = await this.fixture.getOrFetch(inputFile, fetcher);
+    expect(result.mimeType).to.equal('application/zip');
+    expect(result.binaryData.length).to.equal(hashInfo.binaryData.length);
+  });
+
+  it('Should roundtrip binary files synchronously', function() {
+    let inputFile = path.resolve(__dirname, '..', 'test', 'fixtures', 'binaryfile.zip');
+    let hashInfo = this.fileChangeCache.getHashForPathSync(inputFile);
+
+    this.fixture.saveSync(hashInfo, hashInfo.binaryData, 'application/zip');
+
+    let fetcher = function() {
+      throw new Error("No");
+    };
+
+    let result = this.fixture.getOrFetchSync(inputFile, fetcher);
+    expect(result.mimeType).to.equal('application/zip');
+    expect(result.binaryData.length).to.equal(hashInfo.binaryData.length);
+
+    this.fixture = new CompileCache(this.tempCacheDir, this.fileChangeCache);
+
+    result = this.fixture.getOrFetchSync(inputFile, fetcher);
+    expect(result.mimeType).to.equal('application/zip');
+    expect(result.binaryData.length).to.equal(hashInfo.binaryData.length);
+  });
+
+  it('Should only call compile once for the same file synchronously', function() {
+    let inputFile = path.resolve(__dirname, '..', 'src', 'compile-cache.js');
+    let callCount = 0;
+
+    let fetcher = function(filePath, hashInfo) {
+      callCount++;
+
+      let code = hashInfo.sourceCode || fs.readFileSync(filePath, 'utf8');
+      let mimeType = 'application/javascript';
+
+      return { code, mimeType };
+    };
+
+    let result = this.fixture.getOrFetchSync(inputFile, fetcher);
+
+    expect(result.mimeType).to.equal('application/javascript');
+    expect(result.code.length > 10).to.be.ok;
+    expect(callCount).to.equal(1);
+
+    result = this.fixture.getOrFetchSync(inputFile, fetcher);
+
+    expect(result.mimeType).to.equal('application/javascript');
+    expect(result.code.length > 10).to.be.ok;
+    expect(callCount).to.equal(1);
+
+    this.fixture = new CompileCache(this.tempCacheDir, this.fileChangeCache);
+
+    result = this.fixture.getOrFetchSync(inputFile, fetcher);
+
+    expect(result.mimeType).to.equal('application/javascript');
+    expect(result.code.length > 10).to.be.ok;
+    expect(callCount).to.equal(1);
+  });
+
+  it.only('Shouldnt cache compile failures', async function() {
     let inputFile = path.resolve(__dirname, '..', 'lib', 'compile-cache.js');
     let callCount = 0;
     let weBlewUpCount = 0;
-    
+
     let fetcher = async function() {
       callCount++;
       throw new Error("Lolz");
     };
-    
+
     try {
-      await this.fixture.getOrFetch(inputFile, fetcher);    
+      await this.fixture.getOrFetch(inputFile, fetcher);
     } catch (e) {
       weBlewUpCount++;
     }
 
+    console.log(`weBlewUpCount: ${weBlewUpCount}, callCount: ${callCount}`);
     expect(callCount).to.equal(1);
     expect(weBlewUpCount).to.equal(1);
 
     try {
-      await this.fixture.getOrFetch(inputFile, fetcher);    
+      await this.fixture.getOrFetch(inputFile, fetcher);
     } catch (e) {
       weBlewUpCount++;
     }
-    
+
     expect(callCount).to.equal(2);
     expect(weBlewUpCount).to.equal(2);
   });

--- a/test/compile-cache.js
+++ b/test/compile-cache.js
@@ -152,7 +152,6 @@ describe('The compile cache', function() {
       weBlewUpCount++;
     }
 
-    console.log(`weBlewUpCount: ${weBlewUpCount}, callCount: ${callCount}`);
     expect(callCount).to.equal(1);
     expect(weBlewUpCount).to.equal(1);
 


### PR DESCRIPTION
This PR converts the default .compilerc to use babel-preset-env and to automatically detect the version of Electron being used. This means that code generated in electron-forge et al will be by-default as little transpiled as possible.