### PR TITLE
Make require a little faster

### DIFF
--- a/src/compiler-host.js
+++ b/src/compiler-host.js
@@ -71,7 +71,7 @@ export default class CompilerHost {
    *                               if compiler option enabled to emit.
    *                               Default to cachePath if not specified.
    */
-  constructor(rootCacheDir, compilers, fileChangeCache, readOnlyMode, fallbackCompiler = null, sourceMapPath = null) {
+  constructor(rootCacheDir, compilers, fileChangeCache, readOnlyMode, fallbackCompiler = null, sourceMapPath = null, mimeTypesToRegister = null) {
     let compilersByMimeType = Object.assign({}, compilers);
     Object.assign(this, {rootCacheDir, compilersByMimeType, fileChangeCache, readOnlyMode, fallbackCompiler});
     this.appRoot = this.fileChangeCache.appRoot;
@@ -85,6 +85,8 @@ export default class CompilerHost {
         CompileCache.createFromCompiler(rootCacheDir, compiler, fileChangeCache, readOnlyMode, sourceMapPath));
       return acc;
     }, new Map());
+
+    this.mimeTypesToRegister = mimeTypesToRegister || {};
   }
 
   /**
@@ -122,7 +124,7 @@ export default class CompilerHost {
       return acc;
     }, {});
 
-    return new CompilerHost(rootCacheDir, compilers, fileChangeCache, true, fallbackCompiler);
+    return new CompilerHost(rootCacheDir, compilers, fileChangeCache, true, fallbackCompiler, null, info.mimeTypesToRegister);
   }
 
   /**
@@ -164,7 +166,7 @@ export default class CompilerHost {
       compilersByMimeType[x].compilerOptions = cur.compilerOptions;
     });
 
-    return new CompilerHost(rootCacheDir, compilersByMimeType, fileChangeCache, false, fallbackCompiler);
+    return new CompilerHost(rootCacheDir, compilersByMimeType, fileChangeCache, false, fallbackCompiler, null, info.mimeTypesToRegister);
   }
 
 
@@ -193,7 +195,8 @@ export default class CompilerHost {
 
     let info = {
       fileChangeCache: this.fileChangeCache.getSavedData(),
-      compilers: serializedCompilerOpts
+      compilers: serializedCompilerOpts,
+      mimeTypesToRegister: this.mimeTypesToRegister
     };
 
     let target = path.join(this.rootCacheDir, 'compiler-info.json.gz');
@@ -215,8 +218,15 @@ export default class CompilerHost {
    * @property {string[]} dependentFiles  The dependent files returned from
    *                                      compiling the file, if any.
    */
-  compile(filePath) {
-    return (this.readOnlyMode ? this.compileReadOnly(filePath) : this.fullCompile(filePath));
+  async compile(filePath) {
+    let hashInfo = await this.fileChangeCache.getHashForPath(filePath);
+    let ret = await (this.readOnlyMode ? this.compileReadOnly(filePath, hashInfo) : this.fullCompile(filePath, hashInfo));
+
+    if (ret.mimeType === 'application/javascript') {
+      this.mimeTypesToRegister[mimeTypes.lookup(filePath)] = true;
+    }
+
+    return ret;
   }
 
 
@@ -225,7 +235,7 @@ export default class CompilerHost {
    *
    * @private
    */
-  async compileReadOnly(filePath) {
+  async compileReadOnly(filePath, hashInfo) {
     // We guarantee that node_modules are always shipped directly
     let type = mimeTypes.lookup(filePath);
     if (FileChangedCache.isInNodeModules(filePath)) {
@@ -234,8 +244,6 @@ export default class CompilerHost {
         code: await pfs.readFile(filePath, 'utf8')
       };
     }
-
-    let hashInfo = await this.fileChangeCache.getHashForPath(filePath);
 
     // NB: Here, we're basically only using the compiler here to find
     // the appropriate CompileCache
@@ -276,10 +284,8 @@ export default class CompilerHost {
    *
    * @private
    */
-  async fullCompile(filePath) {
+  async fullCompile(filePath, hashInfo) {
     d(`Compiling ${filePath}`);
-
-    let hashInfo = await this.fileChangeCache.getHashForPath(filePath);
     let type = mimeTypes.lookup(filePath);
 
     send('electron-compile-compiled-file', { filePath, mimeType: type });
@@ -401,7 +407,16 @@ export default class CompilerHost {
    */
 
   compileSync(filePath) {
-    return (this.readOnlyMode ? this.compileReadOnlySync(filePath) : this.fullCompileSync(filePath));
+    let hashInfo = this.fileChangeCache.getHashForPathSync(filePath);
+    let ret = (this.readOnlyMode ?
+      this.compileReadOnlySync(filePath, hashInfo) :
+      this.fullCompileSync(filePath, hashInfo));
+
+    if (ret.mimeType === 'application/javascript') {
+      this.mimeTypesToRegister[mimeTypes.lookup(filePath)] = true;
+    }
+
+    return ret;
   }
 
   static createReadonlyFromConfigurationSync(rootCacheDir, appRoot, fallbackCompiler=null) {
@@ -418,7 +433,7 @@ export default class CompilerHost {
       return acc;
     }, {});
 
-    return new CompilerHost(rootCacheDir, compilers, fileChangeCache, true, fallbackCompiler);
+    return new CompilerHost(rootCacheDir, compilers, fileChangeCache, true, fallbackCompiler, null, info.mimeTypesToRegister);
   }
 
   static createFromConfigurationSync(rootCacheDir, appRoot, compilersByMimeType, fallbackCompiler=null) {
@@ -433,7 +448,7 @@ export default class CompilerHost {
       compilersByMimeType[x].compilerOptions = cur.compilerOptions;
     });
 
-    return new CompilerHost(rootCacheDir, compilersByMimeType, fileChangeCache, false, fallbackCompiler);
+    return new CompilerHost(rootCacheDir, compilersByMimeType, fileChangeCache, false, fallbackCompiler, null, info.mimeTypesToRegister);
   }
 
   saveConfigurationSync() {
@@ -454,7 +469,8 @@ export default class CompilerHost {
 
     let info = {
       fileChangeCache: this.fileChangeCache.getSavedData(),
-      compilers: serializedCompilerOpts
+      compilers: serializedCompilerOpts,
+      mimeTypesToRegister: this.mimeTypesToRegister
     };
 
     let target = path.join(this.rootCacheDir, 'compiler-info.json.gz');
@@ -462,7 +478,7 @@ export default class CompilerHost {
     fs.writeFileSync(target, buf);
   }
 
-  compileReadOnlySync(filePath) {
+  compileReadOnlySync(filePath, hashInfo) {
     // We guarantee that node_modules are always shipped directly
     let type = mimeTypes.lookup(filePath);
     if (FileChangedCache.isInNodeModules(filePath)) {
@@ -471,8 +487,6 @@ export default class CompilerHost {
         code: fs.readFileSync(filePath, 'utf8')
       };
     }
-
-    let hashInfo = this.fileChangeCache.getHashForPathSync(filePath);
 
     // We guarantee that node_modules are always shipped directly
     if (hashInfo.isInNodeModules) {
@@ -515,10 +529,9 @@ export default class CompilerHost {
     return { code, mimeType };
   }
 
-  fullCompileSync(filePath) {
+  fullCompileSync(filePath, hashInfo) {
     d(`Compiling ${filePath}`);
 
-    let hashInfo = this.fileChangeCache.getHashForPathSync(filePath);
     let type = mimeTypes.lookup(filePath);
 
     send('electron-compile-compiled-file', { filePath, mimeType: type });

--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -35,11 +35,11 @@ function statSyncNoException(fsPath) {
  * @param {CompilerHost} compilerHost  The compiler host to use.
  *
  */
-export function initializeGlobalHooks(compilerHost) {
+export function initializeGlobalHooks(compilerHost, isProduction=false) {
   let globalVar = (global || window);
   globalVar.globalCompilerHost = compilerHost;
 
-  registerRequireExtension(compilerHost);
+  registerRequireExtension(compilerHost, isProduction);
 
   if ('type' in process && process.type === 'browser') {
     const { app } = require('electron');
@@ -98,7 +98,7 @@ export function init(appRoot, mainModule, productionMode = null, cacheDir = null
     compilerHost = createCompilerHostFromProjectRootSync(appRoot, cachePath, mapPath);
   }
 
-  initializeGlobalHooks(compilerHost);
+  initializeGlobalHooks(compilerHost, productionMode);
   require.main.require(mainModule);
 }
 

--- a/src/config-parser.js
+++ b/src/config-parser.js
@@ -122,9 +122,10 @@ export function createCompilerHostFromConfiguration(info) {
   let fileChangeCache = new FileChangedCache(info.appRoot);
 
   let compilerInfo = path.join(rootCacheDir, 'compiler-info.json.gz');
+  let json = {};
   if (fs.existsSync(compilerInfo)) {
     let buf = fs.readFileSync(compilerInfo);
-    let json = JSON.parse(zlib.gunzipSync(buf));
+    json = JSON.parse(zlib.gunzipSync(buf));
     fileChangeCache = FileChangedCache.loadFromData(json.fileChangeCache, info.appRoot, false);
   }
 
@@ -144,7 +145,7 @@ export function createCompilerHostFromConfiguration(info) {
     compilers[x].compilerOptions = opts;
   });
 
-  let ret = new CompilerHost(rootCacheDir, compilers, fileChangeCache, false, compilers['text/plain']);
+  let ret = new CompilerHost(rootCacheDir, compilers, fileChangeCache, false, compilers['text/plain'], null, json.mimeTypesToRegister);
 
   // NB: It's super important that we guarantee that the configuration is saved
   // out, because we'll need to re-read it in the renderer process

--- a/src/initialize-renderer.js
+++ b/src/initialize-renderer.js
@@ -27,7 +27,7 @@ export function initializeRendererProcess(readOnlyMode) {
   if (readOnlyMode) {
     d(`Setting up electron-compile in precompiled mode with cache dir: ${rootCacheDir}`);
 
-    // NB: React cares SUPER HARD about this, and this is the earliest place 
+    // NB: React cares SUPER HARD about this, and this is the earliest place
     // we can set it up to ensure React picks it up correctly
     process.env.NODE_ENV = 'production';
     compilerHost = CompilerHost.createReadonlyFromConfigurationSync(rootCacheDir, appRoot);
@@ -40,6 +40,6 @@ export function initializeRendererProcess(readOnlyMode) {
   }
 
   require('./x-require');
-  require('./require-hook').default(compilerHost);
+  require('./require-hook').default(compilerHost, readOnlyMode);
   rendererInitialized = true;
 }

--- a/src/require-hook.js
+++ b/src/require-hook.js
@@ -35,7 +35,7 @@ if (process.type === 'renderer') {
  *
  * @param  {CompilerHost} compilerHost  The compiler host to use for compilation.
  */
-export default function registerRequireExtension(compilerHost) {
+export default function registerRequireExtension(compilerHost, isProduction) {
   if (HMR) {
     try {
       require('module').prototype.hot = {
@@ -48,7 +48,11 @@ export default function registerRequireExtension(compilerHost) {
     }
   }
 
-  Object.keys(compilerHost.compilersByMimeType).forEach((mimeType) => {
+  let mimeTypeList = isProduction ?
+    Object.keys(compilerHost.mimeTypesToRegister) :
+    Object.keys(compilerHost.compilersByMimeType);
+
+  mimeTypeList.forEach((mimeType) => {
     let ext = mimeTypes.extension(mimeType);
 
     require.extensions[`.${ext}`] = (module, filename) => {

--- a/test/compiler-host.js
+++ b/test/compiler-host.js
@@ -183,12 +183,16 @@ describe('The compiler host', function() {
       return true;
     });
 
+    expect(Object.keys(this.fixture.mimeTypesToRegister).length > 1).to.be.ok;
+
     d("Saving configuration");
     await this.fixture.saveConfiguration();
 
     d("Recreating from said configuration");
     this.fixture = await CompilerHost.createReadonlyFromConfiguration(this.tempCacheDir, this.appRootDir);
     this.fixture.compileUncached = () => Promise.reject(new Error("Fail!"));
+
+    expect(Object.keys(this.fixture.mimeTypesToRegister).length > 1).to.be.ok;
 
     d("Recompiling everything from cached data");
     await this.fixture.compileAll(input, (filePath) => {


### PR DESCRIPTION
This PR removes the registrations in node.js for extensions you're not using (also, ones that don't actually output JavaScript). This saves a ton of stat calls when you write `require('./foo')` because node would proceed to run down like 15+ extensions trying to find the right one

Baseline:

![image](https://cloud.githubusercontent.com/assets/1396/25069628/18b7eb8e-2287-11e7-93dd-a2868d32a06e.png)

Extensions optimizations:

![image](https://cloud.githubusercontent.com/assets/1396/25074078/4a795280-22f4-11e7-8467-a82c70412bcd.png)

